### PR TITLE
Using abbreviated version of months to avoid the problem

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -76,7 +76,7 @@ define(function(require){
             // formats
             yTickNumberFormat = d3.format('s'),
             xTickDateFormat = d3.time.format('%e'),
-            xTickMonthFormat = d3.time.format('%B'),
+            xTickMonthFormat = d3.time.format('%b'),
 
             // events
             dispatch = d3.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove');

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -102,7 +102,7 @@ define(function(require){
 
             yTickFormat = d3.format('s'),
             xTickFormat = d3.time.format('%e'),
-            xTickMonthFormat = d3.time.format('%B'),
+            xTickMonthFormat = d3.time.format('%b'),
 
             // events
             dispatch = d3.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove');


### PR DESCRIPTION
Using abbreviated version of months to avoid the problem
