### PR TITLE
Limiting tooltip entry text lines to 3 by default

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -46,6 +46,7 @@ define(function(require){
             ttTextX = 0,
             ttTextY = 37,
             textSize,
+            entryLineLimit = 3,
 
             circleYOffset = 8,
 
@@ -364,15 +365,19 @@ define(function(require){
                 while ((word = words.pop())) {
                     line.push(word);
                     tspan.text(line.join(' '));
+
                     if (tspan.node().getComputedTextLength() > width) {
                         line.pop();
                         tspan.text(line.join(' '));
-                        line = [word];
-                        tspan = text.append('tspan')
-                            .attr('x', xpos)
-                            .attr('y', y)
-                            .attr('dy', ++lineNumber * lineHeight + dy + 'em')
-                            .text(word);
+
+                        if (lineNumber < entryLineLimit - 1) {
+                            line = [word];
+                            tspan = text.append('tspan')
+                                .attr('x', xpos)
+                                .attr('y', y)
+                                .attr('dy', ++lineNumber * lineHeight + dy + 'em')
+                                .text(word);
+                        }
                     }
                 }
             });

--- a/test/json/lineDataFiveTopics.json
+++ b/test/json/lineDataFiveTopics.json
@@ -610,7 +610,7 @@
           "fullDate": "2015-08-25T07:00:00.000Z"
         }
       ],
-      "topicName": "Unknown Location with a very long name."
+      "topicName": "Unknown Location with a super hyper mega very very very long name."
     },
     {
       "topic": 60,
@@ -1553,7 +1553,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -1573,7 +1573,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1613,7 +1613,7 @@
         {
           "name": 149,
           "value": 4,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -1638,7 +1638,7 @@
         {
           "name": 149,
           "value": 3,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -1668,7 +1668,7 @@
         {
           "name": 149,
           "value": 1,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -1693,7 +1693,7 @@
         {
           "name": 149,
           "value": 3,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1718,7 +1718,7 @@
         {
           "name": 149,
           "value": 3,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1753,7 +1753,7 @@
         {
           "name": 149,
           "value": 1,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1783,7 +1783,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1813,7 +1813,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1843,7 +1843,7 @@
         {
           "name": 149,
           "value": 4,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -1878,7 +1878,7 @@
         {
           "name": 149,
           "value": 7,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -1908,7 +1908,7 @@
         {
           "name": 149,
           "value": 1,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1933,7 +1933,7 @@
         {
           "name": 149,
           "value": 5,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1968,7 +1968,7 @@
         {
           "name": 149,
           "value": 9,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -1998,7 +1998,7 @@
         {
           "name": 149,
           "value": 5,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2028,7 +2028,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -2058,7 +2058,7 @@
         {
           "name": 149,
           "value": 8,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2088,7 +2088,7 @@
         {
           "name": 149,
           "value": 3,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2118,7 +2118,7 @@
         {
           "name": 149,
           "value": 1,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -2143,7 +2143,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2173,7 +2173,7 @@
         {
           "name": 149,
           "value": 7,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2208,7 +2208,7 @@
         {
           "name": 149,
           "value": 1,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2238,7 +2238,7 @@
         {
           "name": 149,
           "value": 5,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2273,7 +2273,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2303,7 +2303,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2328,7 +2328,7 @@
         {
           "name": 149,
           "value": 5,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2358,7 +2358,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -2383,7 +2383,7 @@
         {
           "name": 149,
           "value": 2,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2418,7 +2418,7 @@
         {
           "name": 149,
           "value": 3,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 81,
@@ -2448,7 +2448,7 @@
         {
           "name": 149,
           "value": 8,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2478,7 +2478,7 @@
         {
           "name": 149,
           "value": 11,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 60,
@@ -2513,7 +2513,7 @@
         {
           "name": 149,
           "value": 17,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2543,7 +2543,7 @@
         {
           "name": 149,
           "value": 14,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2573,7 +2573,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2603,7 +2603,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2633,7 +2633,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2663,7 +2663,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2693,7 +2693,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2723,7 +2723,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2753,7 +2753,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2783,7 +2783,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2813,7 +2813,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2843,7 +2843,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2873,7 +2873,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2903,7 +2903,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2933,7 +2933,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2963,7 +2963,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -2993,7 +2993,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3023,7 +3023,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3053,7 +3053,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3083,7 +3083,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3113,7 +3113,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3143,7 +3143,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3173,7 +3173,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3203,7 +3203,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3233,7 +3233,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3263,7 +3263,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3293,7 +3293,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3323,7 +3323,7 @@
         {
           "name": 149,
           "value": 0,
-          "topicName": "Unknown Location with a very long name."
+          "topicName": "Unknown Location with a super hyper mega very very very long name."
         },
         {
           "name": 0,
@@ -3347,7 +3347,7 @@
     ],
     "topicNames": [
       "San Francisco",
-      "Unknown Location with a very long name.",
+      "Unknown Location with a super hyper mega very very very long name.",
       "Los Angeles",
       "Oakland",
       "Other"


### PR DESCRIPTION
Sometimes the text supposed to go into the tooltip entry lines is too long, so we wanted to limit it to 3 lines max.
