### PR TITLE
Debouncing demos and fixing donut demo bug

### DIFF
--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var d3 = require('d3'),
+var _ = require('underscore'),
+    d3 = require('d3'),
+
     bar = require('./../src/charts/bar'),
     dataBuilder = require('./../test/fixtures/barChartDataBuilder');
 
@@ -33,8 +35,8 @@ function createBarChart() {
 if (d3.select('.js-bar-chart-container').node()){
     createBarChart();
 
-    d3.select(window).on('resize', function(){
+    d3.select(window).on('resize', _.debounce(function(){
         d3.select('.bar-chart').remove();
         createBarChart();
-    });
+    }, 200));
 }

--- a/demos/demo-donut.js
+++ b/demos/demo-donut.js
@@ -1,14 +1,12 @@
 'use strict';
 
-var d3 = require('d3'),
+var _ = require('underscore'),
+    d3 = require('d3'),
+
     donut = require('./../src/charts/donut'),
-    legend = require('./../src/charts/legend');
+    legend = require('./../src/charts/legend'),
 
-
-function createDonutChart() {
-    var donutChart = donut(),
-        legendChart = legend(),
-        dataset = [
+    dataset = [
               {
                 'name': 'Valentines VIP special',
                 'id': 33571136,
@@ -44,8 +42,11 @@ function createDonutChart() {
                 'percentage': 65
               }
         ],
+    legendChart;
+
+function createDonutChart(dataset, legendChart) {
+    var donutChart = donut(),
         donutContainer = d3.select('.js-donut-chart-container'),
-        legendContainer = d3.select('.js-legend-chart-container'),
         containerWidth = donutContainer.node().getBoundingClientRect().width;
 
     d3.select('#button').on('click', function() {
@@ -65,8 +66,14 @@ function createDonutChart() {
         });
 
     donutContainer.datum(dataset).call(donutChart);
+}
+function getLegendChart(dataset) {
+    var legendChart = legend(),
+        legendContainer = d3.select('.js-legend-chart-container');
 
     legendContainer.datum(dataset).call(legendChart);
+
+    return legendChart;
 }
 
 function createSmallDonutChart() {
@@ -127,12 +134,15 @@ function createSmallDonutChart() {
 
 // Show charts if container available
 if (d3.select('.js-donut-chart-container').node()) {
-    createDonutChart();
+    legendChart = getLegendChart(dataset);
+
+    createDonutChart(dataset, legendChart);
     createSmallDonutChart();
 
-    d3.select(window).on('resize', function(){
+    d3.select(window).on('resize', _.debounce(function(){
         d3.selectAll('.donut-chart').remove();
-        createDonutChart();
+
+        createDonutChart(dataset, legendChart);
         createSmallDonutChart();
-    });
+    }, 200));
 }

--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var d3 = require('d3'),
+var _ = require('underscore'),
+    d3 = require('d3'),
+
     line = require('./../src/charts/line'),
     tooltip = require('./../src/charts/tooltip'),
     dataBuilder = require('./../test/fixtures/lineChartDataBuilder');
@@ -70,9 +72,9 @@ if (d3.select('.js-line-chart-container').node()) {
     createLineChart();
     createLineChartWithFixedHeight();
 
-    d3.select(window).on('resize', function(){
+    d3.select(window).on('resize', _.debounce(function(){
         d3.selectAll('.line-chart').remove();
         createLineChart();
         createLineChartWithFixedHeight();
-    });
+    }, 200));
 }

--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var d3 = require('d3'),
+var _ = require('underscore'),
+    d3 = require('d3'),
+
     sparklineChart = require('./../src/charts/sparkline'),
     sparklineDataBuilder = require('./../test/fixtures/sparklineDataBuilder');
 
@@ -12,7 +14,7 @@ function createSparklineChart() {
         container = d3.select('.js-sparkline-chart-container'),
         dataset;
 
-    d3.select("#button").on('click', function() {
+    d3.select('#button').on('click', function() {
         sparkline.exportChart();
     });
 
@@ -30,8 +32,8 @@ function createSparklineChart() {
 if (d3.select('.js-sparkline-chart-container').node()){
     createSparklineChart();
 
-    d3.select(window).on('resize', function(){
+    d3.select(window).on('resize', _.debounce(function(){
         d3.selectAll('.sparkline').remove();
         createSparklineChart();
-    });
+    }, 200));
 }

--- a/demos/demo-stacked-area.js
+++ b/demos/demo-stacked-area.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var d3 = require('d3'),
+var _ = require('underscore'),
+    d3 = require('d3'),
+
     stackedAreaChart = require('./../src/charts/stacked-area'),
     tooltip = require('./../src/charts/tooltip'),
     stackedDataBuilder = require('./../test/fixtures/stackedAreaDataBuilder');
@@ -69,15 +71,14 @@ function createStackedAreaChart() {
 }
 
 
-
 if (d3.select('.js-stacked-area-chart-tooltip-container').node()){
     // Show charts if container available
     createStackedAreaChartWithTooltip();
     createStackedAreaChart();
 
-    d3.select(window).on('resize', function(){
+    d3.select(window).on('resize', _.debounce(function(){
         d3.selectAll('.stacked-area').remove();
         createStackedAreaChartWithTooltip();
         createStackedAreaChart();
-    });
+    }, 200));
 }

--- a/demos/demo-step.js
+++ b/demos/demo-step.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var d3 = require('d3'),
+var _ = require('underscore'),
+    d3 = require('d3'),
+
     step = require('./../src/charts/step'),
     dataBuilder = require('./../test/fixtures/stepChartDataBuilder');
 
@@ -33,8 +35,8 @@ function createStepChart() {
 if (d3.select('.js-step-chart-container').node()){
     createStepChart();
 
-    d3.select(window).on('resize', function(){
+    d3.select(window).on('resize', _.debounce(function(){
         d3.select('.step-chart').remove();
         createStepChart();
-    });
+    }, 200));
 }


### PR DESCRIPTION
The Donut demo was generating multiple legends with every window resize. Fixed.

Added also a debounce on the resizing, so it feels more performant and less 'flicky'
