### PR TITLE
add tasks for untracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "styles": "grunt lint && grunt sass",
     "docs": "WEBPACK_ENV=demos webpack && npm run styles && grunt docs",
     "prod": "npm run _prod && npm run _prodUMD",
+    "untrack": "grunt untrack",
     "release": "npm run prod && grunt release",
     "test": "WEBPACK_ENV=test karma start",
     "_prod": "WEBPACK_ENV=prod webpack",

--- a/src/tasks/helpers/untrack.sh
+++ b/src/tasks/helpers/untrack.sh
@@ -1,0 +1,4 @@
+while read file; do
+    git update-index --assume-unchanged $file
+done <<< `find ./dist -type f`
+

--- a/src/tasks/release.js
+++ b/src/tasks/release.js
@@ -46,4 +46,8 @@ module.exports = function(grunt) {
     grunt.registerTask('bump-dist', function() {
         shell.exec(path.resolve(__dirname, './helpers/push_dist.sh'));
     });
+
+    grunt.registerTask('untrack', function() {
+        shell.exec(path.resolve(__dirname, './helpers/untrack.sh'));
+    });
 };


### PR DESCRIPTION
script to hide all changes to dist if they ever come up in a diff

run with npm run untrack (or grunt untrack but we prefer npm tasks)
