### PR TITLE
Fixing Tooltip Formatting issues

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -88,9 +88,14 @@ define(function(require){
                 small: 10,
                 medium: 100
             },
-            valueFormats = {
+            integerValueFormats = {
+                small: d3.format(''),
+                medium: d3.format(''),
+                large: d3.format('.2s')
+            },
+            decimalValueFormats = {
                 small: d3.format('.3f'),
-                medium: d3.format('.2f'),
+                medium: d3.format('.1f'),
                 large: d3.format('.2s')
             },
 
@@ -222,39 +227,30 @@ define(function(require){
         }
 
         /**
-         * Resets the height of the tooltip and the pointer for the text
-         * position
+         * Formats a floating point value depending on its value range
+         * @param  {Number} value Decimal point value to format
+         * @return {Number}       Formatted value to show
          */
-        function resetSizeAndPositionPointers() {
-            tooltipHeight = 48;
-            ttTextY = 37;
-            ttTextX = 0;
-        }
-
-        function getValueText(topic) {
-            let value = topic.value ? topic.value : topic.views;
-            let valueText;
-
-            if (topic.missingValue) {
-                valueText = '-';
-            } else {
-                valueText = getFormattedValue(value);
-            }
-
-            return valueText;
-        }
-
-        /**
-         * Formats the value depending on the range of the number
-         * @param  {Number} value Value to format
-         * @return {Number}       Formatted value
-         */
-        function getFormattedValue(value) {
+        function formatDecimalValue(value) {
             let size = 'large';
 
-            if (!value) {
-                return 0;
+            if (value < valueRangeLimits.small) {
+                size = 'small';
+            } else if (value < valueRangeLimits.medium) {
+                size = 'medium';
             }
+
+            return decimalValueFormats[size](value);
+        }
+
+
+        /**
+         * Formats an integer value depending on its value range
+         * @param  {Number} value Decimal point value to format
+         * @return {Number}       Formatted value to show
+         */
+        function formatIntegerValue(value) {
+            let size = 'large';
 
             if (value < valueRangeLimits.small) {
                 size = 'small';
@@ -262,7 +258,63 @@ define(function(require){
                 size = 'medium';
             }
 
-            return valueFormats[size](value);
+            return integerValueFormats[size](value);
+        }
+
+        /**
+         * Formats the value depending on its characteristics
+         * @param  {Number} value Value to format
+         * @return {Number}       Formatted value
+         */
+        function getFormattedValue(value) {
+            if (!value) {
+                return 0;
+            }
+
+            if (isInteger(value)) {
+                value = formatIntegerValue(value);
+            } else {
+                value = formatDecimalValue(value);
+            }
+
+            return value;
+        }
+
+        /**
+         * Extracts the value from the data object
+         * @param  {Object} data Data value containing the info
+         * @return {String}      Value to show
+         */
+        function getValueText(data) {
+            let value = data.value ? data.value : data.views;
+            let valueText;
+
+            if (data.missingValue) {
+                valueText = '-';
+            } else {
+                valueText = getFormattedValue(value).toString();
+            }
+
+            return valueText;
+        }
+
+        /**
+         * Checks if a number is an integer of has decimal values
+         * @param  {Number}  value Value to check
+         * @return {Boolean}       If it is an iteger
+         */
+        function isInteger(value) {
+            return value % 1 === 0;
+        }
+
+        /**
+         * Resets the height of the tooltip and the pointer for the text
+         * position
+         */
+        function resetSizeAndPositionPointers() {
+            tooltipHeight = 48;
+            ttTextY = 37;
+            ttTextX = 0;
         }
 
         /**

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -51,7 +51,7 @@ define([
                 it('should have a gradient stroke on the chart line', () => {
                     let stroke = containerFixture.select('.chart-group').selectAll('path').node().style.stroke;
 
-                    expect(stroke).toEqual('url("#line-area-gradient")')
+                    expect(stroke).toEqual('url("#lineGradientId")')
                 });
             });
         });

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -151,68 +151,138 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
 
         describe('Number Formatting', function() {
 
-            it('should format big numbers', () =>  {
-                var expected = '10k',
-                    actual;
+            describe('decimal values', function() {
 
-                tooltipChart.update({
-                    date: '2015-08-05T07:00:00.000Z',
-                    topics: [
-                        {
-                            name: 103,
-                            value: 10000.004,
-                            topicName: 'San Francisco'
-                        }
-                    ]
-                }, topicColorMap, 0);
+                it('should format big numbers', () =>  {
+                    var expected = '10k',
+                        actual;
 
-                actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
-                            .text()
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        topics: [
+                            {
+                                name: 103,
+                                value: 10000.004,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
 
-                expect(actual).toEqual(expected);
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                                .text()
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should format medium numbers', () =>  {
+                    var expected = '100',
+                        actual;
+
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        topics: [
+                            {
+                                name: 103,
+                                value: 100.005,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
+
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                                .text()
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should format small numbers', () =>  {
+                    var expected = '9.123',
+                        actual;
+
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        topics: [
+                            {
+                                name: 103,
+                                value: 9.1234,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
+
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                                .text()
+
+                    expect(actual).toEqual(expected);
+                });
             });
 
-            it('should format medium numbers', () =>  {
-                var expected = '100',
-                    actual;
+            describe('integer values', function() {
 
-                tooltipChart.update({
-                    date: '2015-08-05T07:00:00.000Z',
-                    topics: [
-                        {
-                            name: 103,
-                            value: 100.005,
-                            topicName: 'San Francisco'
-                        }
-                    ]
-                }, topicColorMap, 0);
+                it('should format big numbers', () =>  {
+                    var expected = '10k',
+                        actual;
 
-                actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
-                            .text()
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        topics: [
+                            {
+                                name: 103,
+                                value: 10000,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
 
-                expect(actual).toEqual(expected);
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                                .text()
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should not format medium numbers', () =>  {
+                    var expected = '100',
+                        actual;
+
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        topics: [
+                            {
+                                name: 103,
+                                value: 100,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
+
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                                .text()
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should not format small numbers', () =>  {
+                    var expected = '9',
+                        actual;
+
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        topics: [
+                            {
+                                name: 103,
+                                value: 9,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
+
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                                .text()
+
+                    expect(actual).toEqual(expected);
+                });
             });
 
-            it('should format small numbers', () =>  {
-                var expected = '9.94',
-                    actual;
-
-                tooltipChart.update({
-                    date: '2015-08-05T07:00:00.000Z',
-                    topics: [
-                        {
-                            name: 103,
-                            value: 9.93987,
-                            topicName: 'San Francisco'
-                        }
-                    ]
-                }, topicColorMap, 0);
-
-                actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
-                            .text()
-
-                expect(actual).toEqual(expected);
-            });
         });
 
         describe('API', function() {


### PR DESCRIPTION
Due to my fix for EB-43566: Sales Analytics: Tooltip text overlapping the sum of data values on the report chart were off. I changed my approach to not touching the data and format it on the tooltip.

In this PR I:
- fix test error for gradient url on line chart
- added decimal and integer formatting
- formatting depending on the value range
- tested it
