### PR TITLE
Add feature to plot horizontal lines

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -256,6 +256,8 @@ define(function(require){
             verticalMarkerLine,
             numberFormat,
 
+            customLines = [],
+            verticalLines,
             verticalGridLines,
             horizontalGridLines,
             grid = null,
@@ -439,6 +441,7 @@ define(function(require){
                 .tickFormat(getFormattedValue);
 
             drawGridLines(minor.tick, yTicks);
+            drawCustomLines(minor.tick, yTicks);
         }
 
         /**
@@ -463,6 +466,8 @@ define(function(require){
               .append('g').classed('axis y', true);
             container
               .append('g').classed('grid-lines-group', true);
+            container
+                .append('g').classed('custom-lines-group', true);
             container
               .append('g').classed('chart-group', true);
             container
@@ -791,6 +796,40 @@ define(function(require){
                     .attr('x2', chartWidth)
                     .attr('y1', height - margin.bottom - margin.top)
                     .attr('y2', height - margin.bottom - margin.top);
+        }
+
+        /**
+         * Draws custom user-defined lines onto the chart
+         * @return void
+         */
+        function drawCustomLines(xTicks, yTicks){
+            svg.select('.custom-lines-group')
+                .selectAll('line')
+                .remove();
+
+            let yValues = customLines.map(it => it.y);
+
+            let getColor = yValue => {
+                const definedColor = customLines.find(it => it.y === yValue).color;
+                if(definedColor) {
+                    return definedColor;
+                }
+
+                return 'grey';
+            }
+
+            //draw a horizontal line to extend x-axis till the edges
+            verticalLines = svg.select('.custom-lines-group')
+                .selectAll('line.custom-line')
+                .data(yValues)
+                .enter()
+                .append('line')
+                .attr('class', 'custom-line')
+                .attr('x1', (-xAxisPadding.left - 30))
+                .attr('x2', chartWidth)
+                .attr('y1', (d) => yScale(d))
+                .attr('y2', (d) => yScale(d))
+                .attr('stroke', (d) => getColor(d));
         }
 
         /**
@@ -1506,6 +1545,21 @@ define(function(require){
                 return locale;
             }
             locale = _x;
+
+            return this;
+        };
+
+        /**
+         * Add custom horizontal lines to the Chart
+         * @param  {Object[]} _x  Array of Objects describing the lines
+         * @return { (Object[] | Module) }    Current lines or module to chain calls
+         * @public
+         */
+        exports.lines = function(_x) {
+            if (!arguments.length) {
+                return customLines;
+            }
+            customLines = _x;
 
             return this;
         };

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -258,6 +258,7 @@ define(function(require){
             numberFormat,
 
             customLines = [],
+            defaultCustomLineColor = '#C3C6CF',
             verticalLines,
             verticalGridLines,
             horizontalGridLines,
@@ -816,7 +817,7 @@ define(function(require){
                     return definedColor;
                 }
 
-                return 'grey';
+                return defaultCustomLineColor;
             }
 
             //draw a horizontal line to extend x-axis till the edges
@@ -824,13 +825,13 @@ define(function(require){
                 .selectAll('line.custom-line')
                 .data(yValues)
                 .enter()
-                .append('line')
-                .attr('class', 'custom-line')
-                .attr('x1', (-xAxisPadding.left - verticalShift))
-                .attr('x2', chartWidth)
-                .attr('y1', (d) => yScale(d))
-                .attr('y2', (d) => yScale(d))
-                .attr('stroke', (d) => getColor(d));
+                  .append('line')
+                  .attr('class', 'custom-line')
+                  .attr('x1', 0)
+                  .attr('x2', chartWidth)
+                  .attr('y1', (d) => yScale(d))
+                  .attr('y2', (d) => yScale(d))
+                  .attr('stroke', (d) => getColor(d));
 
             // draw the annotations right above the line at the right end of the chart
             for(let line of customLines) {

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -834,18 +834,16 @@ define(function(require){
 
             // draw the annotations right above the line at the right end of the chart
             for(let line of customLines) {
-                if(!line.name) {
-                    continue;
+                if (line.name) {
+                    svg.select('.custom-lines-group')
+                        .append('text')
+                        .attr('x', chartWidth)
+                        .attr('y', yScale(line.y) - 6)
+                        .attr('class', 'custom-line-annotation')
+                        .attr('text-anchor', 'end')
+                        .attr('dominant-baseline', 'baseline')
+                        .text(line.name);
                 }
-
-                svg.select('.custom-lines-group')
-                    .append('text')
-                    .attr('x', chartWidth)
-                    .attr('y', yScale(line.y) - 6)
-                    .attr('class', 'custom-line-annotation')
-                    .attr('text-anchor', 'end')
-                    .attr('dominant-baseline', 'baseline')
-                    .text(line.name);
             }
         }
 

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -202,6 +202,7 @@ define(function(require){
                 bottom: 0,
                 right: 0
             },
+            verticalShift = 30,
             monthAxisPadding = 28,
             tickPadding = 5,
             colorSchema = colorHelper.colorSchemas.britecharts,
@@ -765,7 +766,7 @@ define(function(require){
                     .enter()
                       .append('line')
                         .attr('class', 'horizontal-grid-line')
-                        .attr('x1', (-xAxisPadding.left - 30))
+                        .attr('x1', (-xAxisPadding.left - verticalShift))
                         .attr('x2', chartWidth)
                         .attr('y1', (d) => yScale(d))
                         .attr('y2', (d) => yScale(d))
@@ -792,7 +793,7 @@ define(function(require){
                 .enter()
                   .append('line')
                     .attr('class', 'extended-x-line')
-                    .attr('x1', (-xAxisPadding.left - 30))
+                    .attr('x1', (-xAxisPadding.left - verticalShift))
                     .attr('x2', chartWidth)
                     .attr('y1', height - margin.bottom - margin.top)
                     .attr('y2', height - margin.bottom - margin.top);
@@ -825,7 +826,7 @@ define(function(require){
                 .enter()
                 .append('line')
                 .attr('class', 'custom-line')
-                .attr('x1', (-xAxisPadding.left - 30))
+                .attr('x1', (-xAxisPadding.left - verticalShift))
                 .attr('x2', chartWidth)
                 .attr('y1', (d) => yScale(d))
                 .attr('y2', (d) => yScale(d))

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -830,6 +830,22 @@ define(function(require){
                 .attr('y1', (d) => yScale(d))
                 .attr('y2', (d) => yScale(d))
                 .attr('stroke', (d) => getColor(d));
+
+            // draw the annotations right above the line at the right end of the chart
+            for(let line of customLines) {
+                if(!line.name) {
+                    continue;
+                }
+
+                svg.select('.custom-lines-group')
+                    .append('text')
+                    .attr('x', chartWidth)
+                    .attr('y', yScale(line.y) - 6)
+                    .attr('class', 'custom-line-annotation')
+                    .attr('text-anchor', 'end')
+                    .attr('dominant-baseline', 'baseline')
+                    .text(line.name);
+            }
         }
 
         /**

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -441,7 +441,7 @@ define(function(require){
                 .tickFormat(getFormattedValue);
 
             drawGridLines(minor.tick, yTicks);
-            drawCustomLines(minor.tick, yTicks);
+            drawCustomLines();
         }
 
         /**
@@ -802,7 +802,7 @@ define(function(require){
          * Draws custom user-defined lines onto the chart
          * @return void
          */
-        function drawCustomLines(xTicks, yTicks){
+        function drawCustomLines(){
             svg.select('.custom-lines-group')
                 .selectAll('line')
                 .remove();

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -1565,10 +1565,16 @@ define(function(require){
         };
 
         /**
-         * Add custom horizontal lines to the Chart
+         * Add custom horizontal lines to the Chart - this way you are able to plot arbitrary horizontal lines
+         * onto the chart with a specific color and a text annotation over the line.
          * @param  {Object[]} _x  Array of Objects describing the lines
          * @return { (Object[] | Module) }    Current lines or module to chain calls
          * @public
+         * @example line.lines([{
+         *   y: 2,
+         *   name: 'Maximum threshold',
+         *   color: '#ff0000'
+         * }])
          */
         exports.lines = function(_x) {
             if (!arguments.length) {

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -808,10 +808,10 @@ define(function(require){
                 .selectAll('line')
                 .remove();
 
-            let yValues = customLines.map(it => it.y);
+            let yValues = customLines.map(line => line.y);
 
             let getColor = yValue => {
-                const definedColor = customLines.find(it => it.y === yValue).color;
+                const definedColor = customLines.find(line => line.y === yValue).color;
                 if(definedColor) {
                     return definedColor;
                 }

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -32,6 +32,12 @@ $line-width: 2;
         stroke-width: 1;
     }
 
+    .custom-line-annotation {
+        font-size: 12px;
+        line-height: 12px;
+        fill: $grey-600;
+    }
+
     // This is the div that we use to simulate a line drawing animation
     // NOTE: it should be of the same color of the background of the chart
     .masking-rectangle {

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -26,6 +26,12 @@ $line-width: 2;
         display: none;
     }
 
+    .custom-line {
+        fill: none;
+        shape-rendering: crispEdges;
+        stroke-width: 1;
+    }
+
     // This is the div that we use to simulate a line drawing animation
     // NOTE: it should be of the same color of the background of the chart
     .masking-rectangle {

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -1,6 +1,7 @@
 @import "../helpers/_variables.scss";
 
 $line-width: 2;
+$text-size: 0.75rem;
 
 .line-chart {
 
@@ -33,8 +34,8 @@ $line-width: 2;
     }
 
     .custom-line-annotation {
-        font-size: 12px;
-        line-height: 12px;
+        font-size: $text-size;
+        line-height: $text-size;
         fill: $grey-600;
     }
 

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -254,6 +254,13 @@ define([
 
                                 expect(actual).toEqual(expected);
                             });
+
+                            it('should not render an annotation text', () => {
+                                const expected = 0;
+                                const actual = containerFixture.select('.custom-line-annotation').size();
+
+                                expect(actual).toEqual(expected);
+                            });
                         })
 
                         describe('when one line is set', () => {
@@ -261,7 +268,8 @@ define([
                             beforeEach(() => {
                                 lineChart = chart().lines([{
                                     y: 2,
-                                    color: '#ff0000'
+                                    color: '#ff0000',
+                                    name: 'Testname'
                                 }]);
 
                                 containerFixture = d3.select('.test-container').append('svg');
@@ -273,6 +281,16 @@ define([
                                 const actual = containerFixture.select('.custom-line').size();
 
                                 expect(actual).toEqual(expected);
+                            });
+
+                            it('should render an annotation text', () => {
+                                const expected = 1;
+                                const actual = containerFixture.select('.custom-line-annotation').size();
+
+                                expect(actual).toEqual(expected);
+
+                                const actualText = containerFixture.select('.custom-lines-group text').text();
+                                expect(actualText).toEqual('Testname');
                             });
                         })
                     });

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -136,6 +136,13 @@ define([
                             expect(actual).toEqual(expected);
                         });
 
+                        it('should create a custom-lines-group', () => {
+                            const expected = 1;
+                            const actual = containerFixture.select('g.custom-lines-group').size();
+
+                            expect(actual).toEqual(expected);
+                        });
+
                         it('should create a metadata-group', () => {
                             const expected = 1;
                             const actual = containerFixture.select('g.metadata-group').size();
@@ -228,6 +235,46 @@ define([
                                 expect(actual).toEqual(expected);
                             });
                         });
+                    });
+
+                    describe('custom lines', () => {
+
+                        describe('when no lines are set', () => {
+
+                            beforeEach(() => {
+                                lineChart = chart();
+
+                                containerFixture = d3.select('.test-container').append('svg');
+                                containerFixture.datum(dataset).call(lineChart);
+                            });
+
+                            it('should not draw a horizontal line', () => {
+                                const expected = 0;
+                                const actual = containerFixture.select('.custom-line').size();
+
+                                expect(actual).toEqual(expected);
+                            });
+                        })
+
+                        describe('when one line is set', () => {
+
+                            beforeEach(() => {
+                                lineChart = chart().lines([{
+                                    y: 2,
+                                    color: '#ff0000'
+                                }]);
+
+                                containerFixture = d3.select('.test-container').append('svg');
+                                containerFixture.datum(dataset).call(lineChart);
+                            });
+
+                            it('should draw a horizontal line', () => {
+                                const expected = 1;
+                                const actual = containerFixture.select('.custom-line').size();
+
+                                expect(actual).toEqual(expected);
+                            });
+                        })
                     });
 
                     describe('axis', () => {
@@ -1080,6 +1127,21 @@ define([
 
                     lineChart.yAxisLabelPadding(expected);
                     actual = lineChart.yAxisLabelPadding();
+
+                    expect(previous).not.toBe(expected);
+                    expect(actual).toBe(expected);
+                });
+
+                it('should provide a lines getter and setter', () => {
+                    let previous = lineChart.lines(),
+                        expected = [{
+                            y: 2,
+                            color: 'grey'
+                        }],
+                        actual;
+
+                    lineChart.lines(expected);
+                    actual = lineChart.lines();
 
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);


### PR DESCRIPTION
Adds the functionality to define arbitrary horizontal lines which are visualized in the line-chart with some annotation directly above the line.

## Description
The user is able to define lines which are visualized in the line-chart. A line is described by the following object:
`
{
y: number;
name: string;
color: string;
}
`

The line will be plotted in the defined color, if no color is given _grey_ is the fallback color. If no name is defined, only the line is drawn but no annotation.

## How Has This Been Tested?
- Test that the _custom-lines-group_ is added
- Test that no line and no annotation is drawn when no lines are defined
- Test that a line and the correct annotation is drawn when one line is defined
- Test that the getter / setter works

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/16606530/79207212-b3eecd80-7e40-11ea-84b0-678c8ba7ca48.png)

## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [ ] No linting issues
- [x] Build is successful
- [x] Code follows the [API Guidelines](http://eventbrite.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [x] Added tests to cover changes
- [x] All new and existing tests passed