### PR TITLE
Add numerical and logarithmic x-axis for stacked-area charts

### DIFF
--- a/src/charts/helpers/axis.js
+++ b/src/charts/helpers/axis.js
@@ -76,6 +76,18 @@ define(function(require) {
     }
 
     /**
+     * Calculates the maximum number of ticks for the x axis
+     * with respect to number ranges
+     * @param  {Number} width               Chart width
+     * @param  {Number} dataPointNumber     Number of entries on the data
+     * @return {Number}                     Number of ticks to render
+     */
+    const getMaxNumOfHorizontalTicksForNumberRanges = (width, dataPointNumber) => {
+        let ticksForWidth = Math.ceil(width / (singleTickWidth + horizontalTickSpacing));
+        return Math.min(dataPointNumber, ticksForWidth);
+    }
+
+    /**
      * Returns tick object to be used when building the x axis
      * @param {dataByDate} dataByDate       Chart data ordered by Date
      * @param {Number} width                Chart width
@@ -112,8 +124,32 @@ define(function(require) {
         };
     };
 
+    /**
+     * Returns tick object to be used when building the x axis
+     * @param {dataSorted} dataSorted       Chart data ordered by Date
+     * @param {Number} width                Chart width
+     * @param {String} [settings=null]      Optional forced settings for axis
+     * @return {object} tick settings for minor axis
+     */
+    const getSortedNumberAxis = (dataSorted, width) => {
+        const firstEntry = dataSorted[0].date;
+        const lastEntry = dataSorted[dataSorted.length - 1].date;
+        const timeSpan = lastEntry - firstEntry;
+
+        const minorTickValue = getMaxNumOfHorizontalTicksForNumberRanges(
+            width,
+            timeSpan
+        );
+
+        return {
+            tick: minorTickValue,
+            format: null
+        };
+    };
+
     return {
-        getTimeSeriesAxis
+        getTimeSeriesAxis,
+        getSortedNumberAxis
     };
 
 });

--- a/src/charts/helpers/axis.js
+++ b/src/charts/helpers/axis.js
@@ -142,8 +142,7 @@ define(function(require) {
         );
 
         return {
-            tick: minorTickValue,
-            format: null
+            tick: minorTickValue
         };
     };
 

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1581,9 +1581,10 @@ define(function(require){
         };
 
         /**
-         * Gets or Sets the xAxisValueType
-         * (Default is date)
-         * @param  {string} [_x=5]      Desired value type of the x-axis
+         * Gets or Sets the `xAxisValueType`.
+         * Choose between 'date' and 'number'. When set to `number` the values of the x-axis must not
+         * be dates anymore, but can be arbitrary numbers.
+         * @param  {string} [_x='date']      Desired value type of the x-axis
          * @return {string | module}    Current value type of the x-axis or Chart module to chain calls
          * @public
          */

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -15,7 +15,7 @@ define(function(require){
 
     const { exportChart } = require('./helpers/export');
     const colorHelper = require('./helpers/color');
-    const { getTimeSeriesAxis } = require('./helpers/axis');
+    const { getTimeSeriesAxis, getSortedNumberAxis } = require('./helpers/axis');
     const { axisTimeCombinations, curveMap } = require('./helpers/constants');
     const {
         formatIntegerValue,
@@ -91,12 +91,13 @@ define(function(require){
             height = 500,
             loadingState = stackedAreaLoadingMarkup,
 
-            xScale, xAxis, xMonthAxis,
+            xScale, xAxis, xSubAxis,
             yScale, yAxis,
 
             aspectRatio = null,
 
             monthAxisPadding = 30,
+            xAxisValueType = 'date',
             yTicks = 5,
             yTickTextYOffset = -8,
             yAxisLabel,
@@ -161,9 +162,9 @@ define(function(require){
             svg,
             chartWidth, chartHeight,
             data,
-            dataByDate,
-            dataByDateFormatted,
-            dataByDateZeroed,
+            dataSorted,
+            dataSortedFormatted,
+            dataSortedZeroed,
 
             verticalGridLines,
             horizontalGridLines,
@@ -215,7 +216,7 @@ define(function(require){
                 chartWidth = width - margin.left - margin.right;
                 chartHeight = height - margin.top - margin.bottom;
                 data = cleanData(_data);
-                dataByDate = getDataByDate(data);
+                dataSorted = getSortedData(data);
 
                 buildLayers();
                 buildScales();
@@ -313,27 +314,34 @@ define(function(require){
         function buildAxis() {
             let minor, major;
 
-            if (xAxisFormat === 'custom' && typeof xAxisCustomFormat === 'string') {
-                minor = {
-                    tick: xTicks,
-                    format:  d3TimeFormat.timeFormat(xAxisCustomFormat)
-                };
+            if(xAxisValueType === 'number') {
+                xAxis = d3Axis.axisBottom(xScale)
+                    .tickFormat(getFormattedValue);
+
+                minor = getSortedNumberAxis(dataSorted, width);
                 major = null;
             } else {
-                ({minor, major} = getTimeSeriesAxis(dataByDate, width, xAxisFormat, locale));
+                if (xAxisFormat === 'custom' && typeof xAxisCustomFormat === 'string') {
+                    minor = {
+                        tick: xTicks,
+                        format: d3TimeFormat.timeFormat(xAxisCustomFormat)
+                    };
+                    major = null;
+                } else {
+                    ({minor, major} = getTimeSeriesAxis(dataSorted, width, xAxisFormat, locale));
 
-                xMonthAxis = d3Axis.axisBottom(xScale)
-                    .ticks(major.tick)
-                    .tickSize(0, 0)
-                    .tickFormat(major.format);
+                    xSubAxis = d3Axis.axisBottom(xScale)
+                        .ticks(major.tick)
+                        .tickSize(0, 0)
+                        .tickFormat(major.format);
+                }
+
+                xAxis = d3Axis.axisBottom(xScale)
+                    .ticks(minor.tick)
+                    .tickSize(10, 0)
+                    .tickPadding(tickPadding)
+                    .tickFormat(minor.format);
             }
-
-            xAxis = d3Axis.axisBottom(xScale)
-                .ticks(minor.tick)
-                .tickSize(10, 0)
-                .tickPadding(tickPadding)
-                .tickFormat(minor.format);
-
 
             yAxis = d3Axis.axisRight(yScale)
                 .ticks(yTicks)
@@ -379,7 +387,7 @@ define(function(require){
          * @private
          */
         function buildLayers() {
-            dataByDateFormatted = dataByDate
+            dataSortedFormatted = dataSorted
                 .map(d => assign({}, d, d.values))
                 .map(d => {
                     Object.keys(d).forEach(k => {
@@ -391,11 +399,11 @@ define(function(require){
                     });
 
                     return assign({}, d, {
-                        date: new Date(d['key'])
+                        date: castValuesToType(d['key'])
                     });
                 });
 
-            dataByDateZeroed = dataByDate
+            dataSortedZeroed = dataSorted
                 .map(d => assign({}, d, d.values))
                 .map(d => {
                     Object.keys(d).forEach(k => {
@@ -407,7 +415,7 @@ define(function(require){
                     });
 
                     return assign({}, d, {
-                        date: new Date(d['key'])
+                        date: castValuesToType(d['key'])
                     });
                 });
 
@@ -428,8 +436,8 @@ define(function(require){
                 .order(d3Shape.stackOrderNone)
                 .offset(d3Shape.stackOffsetNone);
 
-            layersInitial = stack3(dataByDateZeroed);
-            layers = stack3(dataByDateFormatted);
+            layersInitial = stack3(dataSortedZeroed);
+            layers = stack3(dataSortedFormatted);
         }
 
         /**
@@ -468,7 +476,7 @@ define(function(require){
             const maxY = getMaxYAxisScale();
 
             xScale = d3Scale.scaleTime()
-                .domain(d3Array.extent(dataByDate, ({date}) => date))
+                .domain(d3Array.extent(dataSorted, ({date}) => date))
                 .rangeRound([0, chartWidth]);
 
             yScale = d3Scale.scaleLinear()
@@ -535,7 +543,7 @@ define(function(require){
             originalData = originalData.length === 0 ? createFakeData() : originalData;
 
             return originalData.reduce((acc, d) => {
-                d.date = new Date(d[dateLabel]),
+                d.date = castValuesToType(d[dateLabel]),
                 d.value = +d[valueLabel]
 
                 return [...acc, d];
@@ -552,10 +560,10 @@ define(function(require){
                 .attr('transform', `translate( 0, ${chartHeight} )`)
                 .call(xAxis);
 
-            if (xAxisFormat !== 'custom') {
+            if (xAxisFormat !== 'custom' && xAxisValueType !== 'number') {
                 svg.select('.x-axis-group .month-axis')
                     .attr('transform', `translate(0, ${(chartHeight + monthAxisPadding)})`)
-                    .call(xMonthAxis);
+                    .call(xSubAxis);
             }
 
             svg.select('.y-axis-group.axis')
@@ -717,7 +725,7 @@ define(function(require){
             chartGroup
               .append('path')
                 .attr('class', 'empty-data-line')
-                .attr('d', emptyDataLine(dataByDateFormatted))
+                .attr('d', emptyDataLine(dataSortedFormatted))
                 .style('stroke', 'url(#empty-data-line-gradient)');
 
             chartGroup
@@ -899,7 +907,7 @@ define(function(require){
          * @return {Object[]}               Chart data ordered by date
          * @private
          */
-        function getDataByDate(data) {
+        function getSortedData(data) {
             return d3Collection.nest()
                 .key(getDate)
                 .entries(
@@ -907,13 +915,23 @@ define(function(require){
                 )
                 .map(d => {
                     return assign({}, d, {
-                        date: new Date(d.key)
+                        date: castValuesToType(d.key)
                     });
                 });
+        }
 
-            // let b =  d3Collection.nest()
-            //                     .key(getDate).sortKeys(d3Array.ascending)
-            //                     .entries(data);
+        /**
+         * Casts the data given to a date or number
+         * respecting the value of xAxisValueType
+         * @param {string | number} value   Value data
+         * @return {Date | number} value    Casted value
+         */
+        function castValuesToType(value) {
+            if(xAxisValueType === 'number') {
+                return Number(value);
+            }
+
+            return new Date(value);
         }
 
         /**
@@ -932,7 +950,7 @@ define(function(require){
          */
         function getMinValueByDate() {
             let keys = uniq(data.map(o => o.name));
-            let minValueByDate = d3Array.min(dataByDateFormatted, function(d){
+            let minValueByDate = d3Array.min(dataSortedFormatted, function(d){
                 let vals = keys.map((key) => d[key]);
 
                 return d3Array.sum(vals);
@@ -948,7 +966,7 @@ define(function(require){
          */
         function getMaxValueByDate() {
             let keys = uniq(data.map(o => o.name));
-            let maxValueByDate = d3Array.max(dataByDateFormatted, function(d){
+            let maxValueByDate = d3Array.max(dataSortedFormatted, function(d){
                 let vals = keys.map((key) => d[key]);
 
                 return d3Array.sum(vals);
@@ -989,7 +1007,7 @@ define(function(require){
          * @return {obj}        Data entry that is closer to that x axis position
          */
         function getNearestDataPoint(mouseX) {
-            let points = dataByDate.filter(({date}) => Math.abs(xScale(date) - mouseX) <= epsilon);
+            let points = dataSorted.filter(({date}) => Math.abs(xScale(date) - mouseX) <= epsilon);
 
             if (points.length) {
                 return points[0];
@@ -1002,7 +1020,7 @@ define(function(require){
          * @return {Number} half distance between any two points
          */
         function setEpsilon() {
-            let dates = dataByDate.map(({date}) => date);
+            let dates = dataSorted.map(({date}) => date);
 
             epsilon = (xScale(dates[1]) - xScale(dates[0])) / 2;
         }
@@ -1020,7 +1038,7 @@ define(function(require){
                 dataPointXPosition;
 
             if (dataPoint) {
-                dataPointXPosition = xScale(new Date( dataPoint.key ));
+                dataPointXPosition = xScale( dataPoint.key );
                 // Move verticalMarker to that datapoint
                 moveVerticalMarker(dataPointXPosition);
                 // Add data points highlighting
@@ -1557,6 +1575,22 @@ define(function(require){
                 return yTicks;
             }
             yTicks = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the xAxisValueType
+         * (Default is date)
+         * @param  {string} [_x=5]      Desired value type of the x-axis
+         * @return {string | module}    Current value type of the x-axis or Chart module to chain calls
+         * @public
+         */
+        exports.xAxisValueType = function (_x) {
+            if (!arguments.length) {
+                return xAxisValueType;
+            }
+            xAxisValueType = _x;
 
             return this;
         };

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -315,11 +315,12 @@ define(function(require){
             let minor, major;
 
             if(xAxisValueType === 'number') {
-                xAxis = d3Axis.axisBottom(xScale)
-                    .tickFormat(getFormattedValue);
-
                 minor = getSortedNumberAxis(dataSorted, width);
                 major = null;
+
+                xAxis = d3Axis.axisBottom(xScale)
+                    .ticks(minor.tick)
+                    .tickFormat(getFormattedValue);
             } else {
                 if (xAxisFormat === 'custom' && typeof xAxisCustomFormat === 'string') {
                     minor = {

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -319,9 +319,18 @@ define(function(require){
                 minor = getSortedNumberAxis(dataSorted, width);
                 major = null;
 
-                xAxis = d3Axis.axisBottom(xScale)
-                    .ticks(minor.tick)
-                    .tickFormat(getFormattedValue);
+                if(xAxisScale === 'logarithmic') {
+                    xAxis = d3Axis.axisBottom(xScale)
+                        .ticks(minor.tick, "e")
+                        .tickFormat(function (d) {
+                            var log = Math.log(d) / Math.LN10;
+                            return Math.abs(Math.round(log) - log) < 1e-6 ? '10^' + Math.round(log) : '';
+                        });
+                } else {
+                    xAxis = d3Axis.axisBottom(xScale)
+                        .ticks(minor.tick)
+                        .tickFormat(getFormattedValue);
+                }
             } else {
                 if (xAxisFormat === 'custom' && typeof xAxisCustomFormat === 'string') {
                     minor = {

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -98,6 +98,7 @@ define(function(require){
 
             monthAxisPadding = 30,
             xAxisValueType = 'date',
+            xAxisScale = 'linear',
             yTicks = 5,
             yTickTextYOffset = -8,
             yAxisLabel,
@@ -473,21 +474,49 @@ define(function(require){
          * @private
          */
         function buildScales() {
-            const minY = getMinYAxisScale();
-            const maxY = getMaxYAxisScale();
-
-            xScale = d3Scale.scaleTime()
-                .domain(d3Array.extent(dataSorted, ({date}) => date))
-                .rangeRound([0, chartWidth]);
-
-            yScale = d3Scale.scaleLinear()
-                .domain([minY, maxY])
-                .rangeRound([chartHeight, 0])
-                .nice();
+            xScale = buildXAxisScale();
+            yScale = buildYAxisScale();
 
             categoryColorMap =  order.reduce((memo, topic, index) => (
                 assign({}, memo, {[topic]: colorSchema[index]})
             ), {});
+        }
+
+        /**
+         * Creates the xScale depending on the settings of
+         * xAxisValueType and xAxisScale
+         * @private
+         */
+        function buildXAxisScale() {
+            if(xAxisValueType === 'number') {
+                if(xAxisScale === 'logarithmic') {
+                    return d3Scale.scaleLog()
+                        .domain(d3Array.extent(dataSorted, ({ date }) => date))
+                        .rangeRound([0, chartWidth]);
+                } else {
+                    return d3Scale.scaleLinear()
+                        .domain(d3Array.extent(dataSorted, ({ date }) => date))
+                        .rangeRound([0, chartWidth]);
+                }
+            } else {
+                return d3Scale.scaleTime()
+                    .domain(d3Array.extent(dataSorted, ({ date }) => date))
+                    .rangeRound([0, chartWidth]);
+            }
+        }
+
+        /**
+         * Creates the yScale
+         * @private
+         */
+        function buildYAxisScale() {
+            const minY = getMinYAxisScale();
+            const maxY = getMaxYAxisScale();
+
+            return d3Scale.scaleLinear()
+                .domain([minY, maxY])
+                .rangeRound([chartHeight, 0])
+                .nice();
         }
 
         /**
@@ -1593,6 +1622,23 @@ define(function(require){
                 return xAxisValueType;
             }
             xAxisValueType = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the `xAxisScale`.
+         * Choose between 'linear' and 'logarithmic'. The setting will only work if `xAxisValueType` is set to
+         * 'number' as well, otherwise it won't influence the visualization.
+         * @param  {string} [_x='linear']      Desired value type of the x-axis
+         * @return {string | module}    Current value type of the x-axis or Chart module to chain calls
+         * @public
+         */
+        exports.xAxisScale = function (_x) {
+            if (!arguments.length) {
+                return xAxisScale;
+            }
+            xAxisScale = _x;
 
             return this;
         };

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -323,7 +323,7 @@ define(function(require){
                     xAxis = d3Axis.axisBottom(xScale)
                         .ticks(minor.tick, "e")
                         .tickFormat(function (d) {
-                            var log = Math.log(d) / Math.LN10;
+                            const log = Math.log(d) / Math.LN10;
                             return Math.abs(Math.round(log) - log) < 1e-6 ? '10^' + Math.round(log) : '';
                         });
                 } else {
@@ -1625,6 +1625,7 @@ define(function(require){
          * @param  {string} [_x='date']      Desired value type of the x-axis
          * @return {string | module}    Current value type of the x-axis or Chart module to chain calls
          * @public
+         * @example stackedArea.xAxisValueType('numeric')
          */
         exports.xAxisValueType = function (_x) {
             if (!arguments.length) {
@@ -1642,6 +1643,7 @@ define(function(require){
          * @param  {string} [_x='linear']      Desired value type of the x-axis
          * @return {string | module}    Current value type of the x-axis or Chart module to chain calls
          * @public
+         * @example stackedArea.xAxisValueType('numeric').xAxisScale('logarithmic')
          */
         exports.xAxisScale = function (_x) {
             if (!arguments.length) {

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -846,8 +846,8 @@ define(function(require){
         };
 
         /**
-         * Gets or Sets the keyType of the data
-         * The default value is 'date'
+         * Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'. When set to
+         * number, the x-Axis values won't be parsed as dates anymore, but as numbers.
          * @param  {String} [_x='date']     Desired keyType
          * @return {String | module}        Current keyType or Chart module to chain calls
          * @public

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -108,6 +108,7 @@ define(function(require){
             topicLabel = 'topics',
 
             defaultAxisSettings = axisTimeCombinations.DAY_MONTH,
+            xAxisValueType = 'date',
             dateFormat = null,
             dateCustomFormat = null,
             topicsOrder = [],
@@ -408,7 +409,7 @@ define(function(require){
          */
         function updateTitle(dataPoint) {
             let tTitle = title;
-            let formattedDate = formatDate(new Date(dataPoint[dateLabel]));
+            let formattedDate = formatKey(dataPoint[dateLabel]);
 
             if (tTitle.length) {
                 if (shouldShowDateInTitle) {
@@ -419,6 +420,20 @@ define(function(require){
             }
 
             tooltipTitle.text(tTitle);
+        }
+
+        /**
+         * Get formatted key to show in the tooltip title
+         * @param {Date | String} key   Key to format
+         * @return {String}     Formatted Key
+         * @private
+         */
+        function formatKey(key) {
+            if(xAxisValueType === 'number') {
+                return Number(key);
+            }
+
+            return formatDate(new Date(key));
         }
 
         /**
@@ -826,6 +841,22 @@ define(function(require){
                 return valueLabel;
             }
             valueLabel = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the keyType of the data
+         * The default value is 'date'
+         * @param  {String} [_x='date']     Desired keyType
+         * @return {String | module}        Current keyType or Chart module to chain calls
+         * @public
+         */
+        exports.xAxisValueType = function(_x) {
+            if (!arguments.length) {
+                return xAxisValueType;
+            }
+            xAxisValueType = _x;
 
             return this;
         };

--- a/test/fixtures/stackedAreaDataBuilder.js
+++ b/test/fixtures/stackedAreaDataBuilder.js
@@ -8,7 +8,8 @@ define(function(require) {
         jsonSalesChannel = require('../json/areaDataSalesChannel.json'),
         jsonReportService = require('../json/areaDataReportService.json'),
         jsonLargeService = require('../json/areaDataLarge.json'),
-        jsonNegativeValues = require('../json/areaDataNegativeValues.json');
+        jsonNegativeValues = require('../json/areaDataNegativeValues.json'),
+        jsonNumericKeys = require('../json/areaDataNumericKeys.json');
 
 
     function StackedAreaDataBuilder(config){
@@ -51,6 +52,12 @@ define(function(require) {
 
             return new this.Klass(attributes);
         };
+
+        this.withNumericKeys = function() {
+            var attributes = _.extend({}, this.config, jsonNumericKeys);
+
+            return new this.Klass(attributes);
+        }
 
         this.build = function() {
             return this.config;

--- a/test/json/areaDataNumericKeys.json
+++ b/test/json/areaDataNumericKeys.json
@@ -1,0 +1,79 @@
+{
+    "data": [
+        {
+            "date": 5,
+            "name": "Radiant",
+            "views": 5
+        },
+        {
+            "date": 13,
+            "name": "Radiant",
+            "views": 13
+        },
+        {
+            "date": 31,
+            "name": "Radiant",
+            "views": 5
+        },
+        {
+            "date": 42,
+            "name": "Radiant",
+            "views": 13
+        },
+        {
+            "date": 87,
+            "name": "Radiant",
+            "views": 15
+        },
+        {
+            "date": 271,
+            "name": "Radiant",
+            "views": 15
+        },
+        {
+            "date": 571,
+            "name": "Radiant",
+            "views": 18
+        },
+        {
+            "date": 1500,
+            "name": "Radiant",
+            "views": 3
+        },
+        {
+            "date": 3500,
+            "name": "Radiant",
+            "views": 3
+        },
+        {
+            "date": 8400,
+            "name": "Radiant",
+            "views": 23
+        },
+        {
+            "date": 13400,
+            "name": "Radiant",
+            "views": 22
+        },
+        {
+            "date": 87000,
+            "name": "Radiant",
+            "views": 23
+        },
+        {
+            "date": 130400,
+            "name": "Radiant",
+            "views": 22
+        },
+        {
+            "date": 1350000,
+            "name": "Radiant",
+            "views": 23
+        },
+        {
+            "date": 12000000,
+            "name": "Radiant",
+            "views": 22
+        }
+    ]
+}

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -788,6 +788,18 @@ define([
                 expect(defaultYAxisLabelOffset).not.toEqual(newYAxisLabelOffset);
                 expect(newYAxisLabelOffset).toEqual(testYAxisLabelOffset);
             });
+
+            it('should provide xAxisValueType getter and setter', () => {
+                let defaultXAxisValueType =  stackedAreaChart.yAxisLabelOffset(),
+                    testXAxisValueType = 'number',
+                    newXAxisValueType;
+
+                stackedAreaChart.yAxisLabelOffset(testXAxisValueType);
+                newXAxisValueType = stackedAreaChart.yAxisLabelOffset();
+
+                expect(defaultXAxisValueType).not.toEqual(newXAxisValueType);
+                expect(newXAxisValueType).toEqual(testXAxisValueType);
+            });
         });
     });
 });

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -204,6 +204,45 @@ define([
 
                     expect(actual).toEqual(expected);
                 });
+
+                describe('when x-axis value type is number', () => {
+
+                    beforeEach(function () {
+                        dataset = aTestDataSet().withNumericKeys().build();
+                        stackedAreaChart = stackedArea()
+                            .xAxisValueType('number')
+                            .dateLabel('date');
+
+                        containerFixture = d3.select('.test-container').append('svg');
+                        containerFixture.datum(dataset.data).call(stackedAreaChart);
+                    });
+
+                    it('the highest X-axis value is a number', () => {
+                        let yAxis = containerFixture.selectAll('.x-axis-group');
+                        let text = yAxis.select('g.tick:last-child');
+                        expect(text.text()).toEqual('12M');
+                    });
+                });
+
+                describe('when x-axis value type is number and scale is logarithmic', () => {
+
+                    beforeEach(function () {
+                        dataset = aTestDataSet().withNumericKeys().build();
+                        stackedAreaChart = stackedArea()
+                            .xAxisValueType('number')
+                            .xAxisScale('logarithmic')
+                            .dateLabel('date');
+
+                        containerFixture = d3.select('.test-container').append('svg');
+                        containerFixture.datum(dataset.data).call(stackedAreaChart);
+                    });
+
+                    it('the highest X-axis value is a logarithmic number', () => {
+                        let yAxis = containerFixture.selectAll('.x-axis-group');
+                        let text = yAxis.select('g.tick:last-child');
+                        expect(text.text()).toEqual('10^7');
+                    });
+                });
             });
 
             it('should render an area for each category', () => {
@@ -799,6 +838,23 @@ define([
 
                 expect(defaultXAxisValueType).not.toEqual(newXAxisValueType);
                 expect(newXAxisValueType).toEqual(testXAxisValueType);
+            });
+
+            it('should provide xAxisScale getter and setter', () => {
+                let defaultXAxisScale =  stackedAreaChart.xAxisScale(),
+                    testXAxisScale = 'logarithmic',
+                    newXAxisScale;
+
+                stackedAreaChart.xAxisScale(testXAxisScale);
+                newXAxisScale = stackedAreaChart.xAxisScale();
+
+                expect(defaultXAxisScale).not.toEqual(newXAxisScale);
+                expect(newXAxisScale).toEqual(testXAxisScale);
+            });
+
+            it('default of xAxisValueType should be "date"', () => {
+                let current = stackedAreaChart.xAxisValueType();
+                expect(current).toBe('date');
             });
         });
     });

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -468,6 +468,23 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                 expect(current).not.toBe(expected);
                 expect(actual).toBe(expected);
             });
+
+            it('should provide xAxisValueType getter and setter', () => {
+                let current = tooltipChart.xAxisValueType(),
+                    expected = 'number',
+                    actual;
+
+                tooltipChart.xAxisValueType(expected);
+                actual = tooltipChart.xAxisValueType();
+
+                expect(current).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('default of xAxisValueType should be "date"', () => {
+                let current = tooltipChart.xAxisValueType();
+                expect(current).toBe('date');
+            });
         });
     });
 });

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -142,6 +142,24 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                         expect(actual).toBe(expected);
                     });
                 });
+
+                describe('when xAxisValueType is set to number', () => {
+                    it('should show the number in the title of the tooltip', () => {
+                        const expected = 'Tooltip title - 20000';
+                        let actual;
+
+                        tooltipChart.xAxisValueType('number');
+                        tooltipChart.update({
+                            date: 20000,
+                            topics: []
+                        }, topicColorMap, 0);
+                        actual = containerFixture.select('.britechart-tooltip')
+                            .selectAll('.tooltip-title')
+                            .text();
+
+                        expect(actual).toEqual(expected);
+                    });
+                })
             });
         });
 


### PR DESCRIPTION
Adds the functionality to use numerical values as x-values to plot, instead of only dates - this can be achieved by setting `.xAxisValueType('number')` - the default behaviour will be the same (so we introduce no breaking API changes!). 

The user can use the same method for the tooltip to change the formatting of the x-values in the tooltip-title.

Additionally you can modify the area-chart with `.xAxisScale('logarithmic')` to show a logarithmic scaled axis. 

## How Has This Been Tested?
- Test when xAxisValueType is set to numeric that the x-Axis ticks are not dates anymore but numbers
- Test when xAxisValueType is set to numeric and xAxisScale to logarithmic, that the x-Axis ticks are in the format `10^x` and not dates anymore
- Test the getter / setter for `xAxisValueType` and `xAxisScale` for the stacked-area chart
- Test the getter / setter for `xAxisValueType` for the tooltip
- Test when xAxisValueType is set to numeric for the tooltip, no dates are shown in the title, but the numerical value

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/16606530/79214858-51e79580-7e4b-11ea-9c6f-fef2de848008.png)

![image](https://user-images.githubusercontent.com/16606530/79214980-675cbf80-7e4b-11ea-98cb-cc586dc64fb1.png)


## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I did not want to introduce any breaking change in the API, so I did not refactor the variable-namings, etc. too much. This means that it might be strange now if you have variables with `date` in it but the value of the variable does not need to be a date anymore.

For me at least it's now consistent to the other chart-types and the refactoring of namings, etc. may be done in a bigger MR when rolling out these features for all charts?

## Checklist:
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [ ] No linting issues
- [x] Build is successful
- [x] Code follows the [API Guidelines](http://eventbrite.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [x] Added tests to cover changes
- [x] All new and existing tests passed