### PR TITLE
Add support for multirow tooltip title

### DIFF
--- a/src/charts/helpers/text.js
+++ b/src/charts/helpers/text.js
@@ -150,9 +150,41 @@ define(function(require) {
         return b.measureText(text).width;
     }
 
+    /**
+     * Heuristic which gets the number of lines needed to display the title of the tooltip
+     * If shouldShowDateInTitle is set to true, it takes the formatted Date.now() as additional influencer
+     * for the approximation of the needed number of lines.
+     * @param  {String}  text  Text which shall be tested for the necessary number of lines
+     * @param  {Number}  fontSize  Fontsize to use for the heuristic
+     * @param  {Number}  maxLength  Maximal length per line
+     * @return  {Number}  approximateLineNumber  Approximative number of lines needed to display the title
+     * @private
+     */
+    const getApproximateNumberOfLines = function(title, fontSize, maxLength) {
+        const words = title.split(/\s+/).reverse();
+
+        var word,
+            line = [],
+            approximateLineNumber = 1;
+
+        while (word = words.pop()) {
+            line.push(word);
+
+            const textWidth = getTextWidth(line.join(' '), fontSize, 'Karla, sans-serif');
+            if (textWidth > maxLength) {
+                line.pop();
+                line = [word];
+                ++approximateLineNumber;
+            }
+        }
+
+        return approximateLineNumber;
+    }
+
     return {
         getTextWidth,
         wrapText,
-        wrapTextWithEllipses
+        wrapTextWithEllipses,
+        getApproximateNumberOfLines
     };
 });

--- a/src/charts/helpers/text.js
+++ b/src/charts/helpers/text.js
@@ -163,11 +163,10 @@ define(function(require) {
     const getApproximateNumberOfLines = function(title, fontSize, maxLength) {
         const words = title.split(/\s+/).reverse();
 
-        var word,
-            line = [],
+        let line = [],
             approximateLineNumber = 1;
 
-        while (word = words.pop()) {
+        for(let word of words) {
             line.push(word);
 
             const textWidth = getTextWidth(line.join(' '), fontSize, 'Karla, sans-serif');

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -418,7 +418,7 @@ define(function(require){
                 tooltipMaxTitleLength
             );
 
-            if(approximateNumberOfTitleLines > 1) {
+            if (approximateNumberOfTitleLines > 1) {
                 additionalTooltipTitleHeight = 17 * (approximateNumberOfTitleLines -1)
             }
         }
@@ -430,10 +430,10 @@ define(function(require){
          * @private
          */
         function updateTitle(dataPoint) {
-            const tTitle = getTooltipTitle(dataPoint[dateLabel]);
+            const textTitle = getTooltipTitle(dataPoint[dateLabel]);
 
             tooltipTitle
-                .text(tTitle)
+                .text(textTitle)
                 .call(textWrap, tooltipMaxTitleLength, getTooltipTitleXPosition());
         }
 
@@ -443,18 +443,18 @@ define(function(require){
          * @private
          */
         function getTooltipTitle(date) {
-            let tTitle = title;
+            let textTitle = title;
             let formattedDate = formatKey(date);
 
-            if (tTitle.length) {
+            if (textTitle.length) {
                 if (shouldShowDateInTitle) {
-                    tTitle = `${tTitle} - ${formattedDate}`;
+                    textTitle = `${textTitle} - ${formattedDate}`;
                 }
             } else {
-                tTitle = formattedDate;
+                textTitle = formattedDate;
             }
 
-            return tTitle;
+            return textTitle;
         }
 
         /**

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -444,7 +444,7 @@ define(function(require){
          */
         function getTooltipTitle(date) {
             let tTitle = title;
-            let formattedDate = formatKey(dataPoint[dateLabel]);
+            let formattedDate = formatKey(date);
 
             if (tTitle.length) {
                 if (shouldShowDateInTitle) {

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -14,7 +14,7 @@ define(function(require){
         isInteger
     } = require('./helpers/number');
 
-    const {getTextWidth} = require('./helpers/text');
+    const {getTextWidth, getApproximateNumberOfLines} = require('./helpers/text');
 
     /**
      * Tooltip Component reusable API class that renders a
@@ -411,39 +411,16 @@ define(function(require){
          * initialTooltipBodyYPosition accordingly
          */
         function updateTooltipTitleYPosition() {
-            const approximateNumberOfTitleLines = getApproximateNumberOfLines();
+            const approximateTitle = getTooltipTitle(Date.now());
+            const approximateNumberOfTitleLines = getApproximateNumberOfLines(
+                approximateTitle,
+                16,
+                tooltipMaxTitleLength
+            );
+
             if(approximateNumberOfTitleLines > 1) {
                 additionalTooltipTitleHeight = 17 * (approximateNumberOfTitleLines -1)
             }
-        }
-
-        /**
-         * Heuristic which gets the number of lines needed to display the title of the tooltip
-         * If shouldShowDateInTitle is set to true, it takes the formatted Date.now() as additional influencer
-         * for the approximation of the needed number of lines.
-         * @return  {Number}  approximateLineNumber  Approximative number of lines needed to display the title
-         * @private
-         */
-        function getApproximateNumberOfLines() {
-            const approximativeTitle = getTooltipTitle(Date.now());
-            const words = approximativeTitle.split(/\s+/).reverse();
-
-            var word,
-                line = [],
-                approximateLineNumber = 1;
-
-            while (word = words.pop()) {
-                line.push(word);
-
-                const textWidth = getTextWidth(line.join(' '), 16, 'Karla, sans-serif');
-                if (textWidth > tooltipMaxTitleLength) {
-                    line.pop();
-                    line = [word];
-                    ++approximateLineNumber;
-                }
-            }
-
-            return approximateLineNumber;
         }
 
         /**

--- a/test/specs/helpers.spec.js
+++ b/test/specs/helpers.spec.js
@@ -113,6 +113,16 @@ define([
                 expect(actualValueCount).toEqual(expectedValueCount);
                 expect(actualLabelCount).toEqual(expectedLabelCount);
             });
+
+            it('should calculate the number of necessary lines to render the text', () => {
+                const text = 'This is a super long text';
+                const fontSize = 16;
+                const availableWidth = 150;
+                const expectedNumberOfLines = 2;
+
+                const actualNumberOfLines = textHelper.getApproximateNumberOfLines(text, fontSize, availableWidth);
+                expect(actualNumberOfLines).toEqual(expectedNumberOfLines);
+            });
         });
 
         describe('number', () => {

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -122,6 +122,57 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
 
                         expect(actual).toEqual(expected);
                     });
+
+                });
+
+                describe('when title is long', () => {
+
+                    beforeEach(() => {
+                        dataset = [];
+                        tooltipChart = tooltip().title('Super long and exciting Tooltip title');
+
+                        // DOM Fixture Setup
+                        f = jasmine.getFixtures();
+                        f.fixturesPath = 'base/test/fixtures/';
+                        f.load('testContainer.html');
+
+                        containerFixture = d3.select('.test-container').append('svg');
+                        containerFixture.datum(dataset).call(tooltipChart);
+                    });
+
+                    afterEach(() => {
+                        containerFixture.remove();
+                        f = jasmine.getFixtures();
+                        f.cleanUp();
+                        f.clearCache();
+                    });
+
+                    it('should be displayed in two rows', () => {
+                        // the space between 'Tooltip' and 'title' dissappears because of the text wrap
+                        const expectedTitle = 'Super long and exciting Tooltiptitle - Aug 05, 2015';
+                        const expectedDividerYPosition = 48;
+                        let actualTitle, actualDividerY1Position, actualDividerY2Position;
+
+                        tooltipChart.dateFormat(tooltipChart.axisTimeCombinations.DAY_MONTH);
+                        tooltipChart.update({
+                            date: '2015-08-05T07:00:00.000Z',
+                            topics: []
+                        }, topicColorMap, 0);
+
+                        actualTitle = containerFixture.select('.britechart-tooltip')
+                            .selectAll('.tooltip-title')
+                            .text();
+
+                        actualDividerY1Position = containerFixture.select('.britechart-tooltip')
+                            .select('.tooltip-divider').attr('y1');
+
+                        actualDividerY2Position = containerFixture.select('.britechart-tooltip')
+                            .select('.tooltip-divider').attr('y2');
+
+                        expect(actualTitle).toEqual(expectedTitle);
+                        expect(parseInt(actualDividerY1Position)).toEqual(expectedDividerYPosition);
+                        expect(parseInt(actualDividerY2Position)).toEqual(expectedDividerYPosition);
+                    });
                 });
 
                 describe('when date must not be shown', () => {


### PR DESCRIPTION
This PR adds support for text wrap of the tooltip title - currently the title + current date would just overlap the tooltip, but now the existing textWrap functionality is used for the title as well.

## Motivation and Context
Long tooltip titles + date formats break the style of the tooltip, so the solution is a text wrap for the title row as well.

## How Has This Been Tested?
- Test if the tooltipDivider changes the y-Position in case of a long title and check if the title is correct wrapped

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/16606530/79695416-0c75fe80-8277-11ea-9acd-1a8c77ea7f17.png)

After:
![image](https://user-images.githubusercontent.com/16606530/79695392-f0725d00-8276-11ea-8a85-675a5bdfe106.png)

## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [ ] No linting issues
- [x] Build is successful
- [ ] Code follows the [API Guidelines](http://eventbrite.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [x] Added tests to cover changes
- [x] All new and existing tests passed