### PR TITLE
Fixes tooltip of stacked area chart

### DIFF
--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1087,7 +1087,7 @@ define(function(require){
                 dataPointXPosition;
 
             if (dataPoint) {
-                dataPointXPosition = xScale( dataPoint.key );
+                dataPointXPosition = xScale(castValueToType(dataPoint.key));
                 // Move verticalMarker to that datapoint
                 moveVerticalMarker(dataPointXPosition);
                 // Add data points highlighting


### PR DESCRIPTION
Tooltip was unfortunately broken in the change to support numerical and logarithmic x-axis for stacked-area charts:

## Description
The tooltip is not shown correctly anymore for the stacked-area-chart.

## Motivation and Context
Bugfix.

## How Has This Been Tested?
- no idea how to test this

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/16606530/80180122-560d7300-8602-11ea-94f9-283614ef1d46.png)

After:
![image](https://user-images.githubusercontent.com/16606530/80180107-4beb7480-8602-11ea-8417-e39d58b95e1b.png)

## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Build is successful
- [x] Code follows the [API Guidelines](http://eventbrite.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [ ] Added tests to cover changes
- [x] All new and existing tests passed