### PR TITLE
Use fill:none; styling directly in SVG instead of external CSS file

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -882,7 +882,8 @@ define(function(require){
                   .attr('x2', chartWidth)
                   .attr('y1', (d) => yScale(d))
                   .attr('y2', (d) => yScale(d))
-                  .attr('stroke', (d) => getColor(d));
+                  .attr('stroke', (d) => getColor(d))
+                  .attr('fill', 'none');
 
             // draw the annotations right above the line at the right end of the chart
             for(let line of customLines) {

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -791,7 +791,8 @@ define(function(require){
                 .attr('d', ({dates}) => topicLine(dates))
                 .style('stroke', (d) => (
                     dataByTopic.length === 1 ? `url(#${lineGradientId})` : getLineColor(d)
-                ));
+                ))
+                .style('fill', 'none');
 
             lines
                 .exit()

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -327,7 +327,8 @@ define(function(require){
                 .attr('class', 'line')
                 .attr('stroke', `url(#${lineGradientId})`)
                 .attr('d', topLine)
-                .attr('clip-path', `url(#${maskingClipId})`);
+                .attr('clip-path', `url(#${maskingClipId})`)
+                .attr('fill', 'none');
         }
 
         /**

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -857,7 +857,8 @@ define(function(require){
                   .append('path')
                     .attr('class', 'area-outline')
                     .attr('d', areaOutline)
-                    .style('stroke', ({key}) => categoryColorMap[key]);
+                    .style('stroke', ({key}) => categoryColorMap[key])
+                    .style('fill', 'none');
 
                 // Update
                 svg.select('.chart-group').selectAll('.layer')
@@ -896,7 +897,8 @@ define(function(require){
                   .append('path')
                     .attr('class', 'area-outline')
                     .attr('d', areaOutline)
-                    .style('stroke', ({key}) => categoryColorMap[key]);
+                    .style('stroke', ({key}) => categoryColorMap[key])
+                    .style('fill', 'none');
 
 
                 // Update
@@ -908,7 +910,8 @@ define(function(require){
                 svg.select('.chart-group').selectAll('.area-outline')
                     .attr('class', 'area-outline')
                     .attr('d', areaOutline)
-                    .style('stroke', ({key}) => categoryColorMap[key]);
+                    .style('stroke', ({key}) => categoryColorMap[key])
+                    .style('fill', 'none');
             }
 
             if (!hasOutline) {

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -12,7 +12,6 @@ $text-size: 0.75rem;
 
     // Lines
     .topic .line {
-        fill: none;
         stroke-width: $line-width;
         stroke-linecap: round;
         stroke-linejoin: round;

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -27,7 +27,6 @@ $text-size: 0.75rem;
     }
 
     .custom-line {
-        fill: none;
         shape-rendering: crispEdges;
         stroke-width: 1;
     }

--- a/src/styles/charts/sparkline.scss
+++ b/src/styles/charts/sparkline.scss
@@ -6,7 +6,6 @@ $dot-size: 0;
 .sparkline {
     stroke: $grey-500;
     stroke-width: $line-width;
-    fill: none;
     stroke-linecap: round;
     stroke-linejoin: round;
 

--- a/src/styles/charts/stacked-area.scss
+++ b/src/styles/charts/stacked-area.scss
@@ -19,7 +19,6 @@ $outline-stroke-width: 1.2;
 
     .area-outline {
         shape-rendering: geometricPrecision;
-        fill: none;
         stroke-width: $outline-stroke-width;
     }
 


### PR DESCRIPTION
I moved an important styling to the generated SVG directly instead of having it injected by the external CSS file describing several styles of the chart.

## Motivation and Context
When you currently extract the SVG of the chart and use Inkscape to generate a PDF out of it, the CSS styles are not loaded, therefore the exported PDF does not look nice (because of the `fill:none;` missing:
![image](https://user-images.githubusercontent.com/16606530/89313827-4aa5fb00-d679-11ea-83d2-5c3fa9fff2b3.png)

After my changes the generated PDF would look like this:
![image](https://user-images.githubusercontent.com/16606530/89314013-745f2200-d679-11ea-8fd3-3aae6a82e309.png)

## How Has This Been Tested?
I did not change any tests nor added tests for it.

## Types of changes
- [x] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Build is successful
- [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [ ] Added tests to cover changes
- [x] All new and existing tests passed