### PR TITLE
fix bug that bars are shown if all values are 0

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -293,7 +293,7 @@ define(function(require) {
          * @private
          */
         function buildScales() {
-            let percentageAxis = Math.min(percentageAxisToMaxRatio * d3Array.max(data, getValue))
+            let percentageAxis = getPercentageAxis()
 
             if (isHorizontal) {
                 xScale = d3Scale.scaleLinear()
@@ -828,6 +828,21 @@ define(function(require) {
          */
         function handleClick(e, d, chartWidth, chartHeight) {
             dispatcher.call('customClick', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
+        }
+
+        /**
+         * Gets the percentageAxis, sets it to 1 if all data points are 0
+         * @return {number} Calculated percentageAxis
+         * @private
+         */
+        function getPercentageAxis() {
+            const uniqueDataPoints = new Set(data.map(x => x.value))
+            const allZeroes = uniqueDataPoints.size === 1 && uniqueDataPoints.has(0)
+            if(allZeroes) {
+                return percentageAxisToMaxRatio
+            }
+
+            return Math.min(percentageAxisToMaxRatio * d3Array.max(data, getValue))
         }
 
         // API

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -836,7 +836,7 @@ define(function(require) {
          * @private
          */
         function getPercentageAxis() {
-            const uniqueDataPoints = new Set(data.map(x => x.value));
+            const uniqueDataPoints = new Set(data.map(getValue));
             const allZeroes = uniqueDataPoints.size === 1 && uniqueDataPoints.has(0);
             if (allZeroes) {
                 return percentageAxisToMaxRatio;

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -293,7 +293,7 @@ define(function(require) {
          * @private
          */
         function buildScales() {
-            let percentageAxis = getPercentageAxis()
+            let percentageAxis = getPercentageAxis();
 
             if (isHorizontal) {
                 xScale = d3Scale.scaleLinear()
@@ -836,13 +836,13 @@ define(function(require) {
          * @private
          */
         function getPercentageAxis() {
-            const uniqueDataPoints = new Set(data.map(x => x.value))
-            const allZeroes = uniqueDataPoints.size === 1 && uniqueDataPoints.has(0)
-            if(allZeroes) {
-                return percentageAxisToMaxRatio
+            const uniqueDataPoints = new Set(data.map(x => x.value));
+            const allZeroes = uniqueDataPoints.size === 1 && uniqueDataPoints.has(0);
+            if (allZeroes) {
+                return percentageAxisToMaxRatio;
             }
 
-            return Math.min(percentageAxisToMaxRatio * d3Array.max(data, getValue))
+            return Math.min(percentageAxisToMaxRatio * d3Array.max(data, getValue));
         }
 
         // API

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -831,7 +831,7 @@ define(function(require) {
         }
 
         /**
-         * Gets the percentageAxis, sets it to 1 if all data points are 0
+         * Gets the percentageAxis, sets it to `percentageAxisToMaxRatio` if all data points are 0
          * @return {number} Calculated percentageAxis
          * @private
          */


### PR DESCRIPTION
## Description

Fixes the problem that bars are shown even if all values are 0 and no bars should be shown - fixes it by setting the domain of the y axis to `[0, percentageAxisToMaxRatio]` instead of `[0, 0]` which causes the visualization problems.

## Motivation and Context
https://github.com/britecharts/britecharts/issues/827

## How Has This Been Tested?
-

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/16606530/89613124-c5d9fd80-d881-11ea-930f-f4d10ae67c97.png)

After:
![image](https://user-images.githubusercontent.com/16606530/89613133-cd99a200-d881-11ea-8497-c97707a99acc.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Build is successful
- [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [ ] Added tests to cover changes
- [x] All new and existing tests passed