### PR TITLE
fix-554 - Animating line chart by drawing path

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -1,5 +1,3 @@
-const { path } = require('d3-path');
-
 define(function(require){
     'use strict';
 
@@ -14,6 +12,7 @@ define(function(require){
     const d3Selection = require('d3-selection');
     const d3Transition = require('d3-transition');
     const d3TimeFormat = require('d3-time-format');
+    const path = require('d3-path');
 
     const { exportChart } = require('./helpers/export');
     const colorHelper = require('./helpers/color');
@@ -235,8 +234,9 @@ define(function(require){
             isAnimated = false,
             ease = d3Ease.easeQuadInOut,
             easeLiner = d3Ease.easeLinear,
-            animationDuration = 1500,
-            maskingRectangle,
+            animationDuration = 3000,
+            strokeDashoffset = 10,
+            strokeDasharrayOffset = 3,
 
             lineCurve = 'linear',
 
@@ -686,30 +686,6 @@ define(function(require){
         }
 
         /**
-         * Creates a masking clip that would help us fake an animation if the
-         * proper flag is true
-         *
-         * @return {void}
-         */
-        function createMaskingClip() {
-            if (isAnimated) {
-                // We use a white rectangle to simulate the line drawing animation
-                maskingRectangle = svg.append('rect')
-                    .attr('class', 'masking-rectangle')
-                    .attr('width', width)
-                    .attr('height', height)
-                    .attr('x', 0)
-                    .attr('y', 0);
-
-                maskingRectangle.transition()
-                    .duration(animationDuration)
-                    .ease(ease)
-                    .attr('x', width)
-                    .on('end', () => maskingRectangle.remove());
-            }
-        }
-
-        /**
          * Draws the x and y axis on the svg object within their
          * respective groups along with the axis labels if given
          * @private
@@ -808,12 +784,12 @@ define(function(require){
                 const totalLength = paths.node().getTotalLength();
 
                 paths
-                    .attr('stroke-dasharray', totalLength + ' ' + 3*totalLength)
+                    .attr('stroke-dasharray', totalLength + ' ' + strokeDasharrayOffset * totalLength)
                     .attr('stroke-dashoffset', totalLength)
                     .transition()
                     .ease(easeLiner)
-                    .duration(3000)
-                    .attr('stroke-dashoffset', 10);
+                    .duration(animationDuration)
+                    .attr('stroke-dashoffset', strokeDashoffset);
 
             }
         }


### PR DESCRIPTION
Fixes #554 

fix - line chart animation

## Description

Introduced a new function called animateLines() that is called instead of createMaskingClip()
Lines are animated by retracing the path using transition

## Motivation and Context

Fixes #554 

## How Has This Been Tested?

Changes are tested in local environment. Since the change involves look and feel that aspect is tested. Regression test is run to make sure nothing is broken

## Screenshots (if appropriate):


![linechart1](https://user-images.githubusercontent.com/10022651/137072576-4d178f5c-84c8-4bc6-83de-c50a67cf9731.gif)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Latest master code has been merged into this branch
-   [ ] No commented out code (if required, place // TODO above with explanation)
-   [ ] No linting issues
-   [ ] Build is successful
-   [ ] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [ ] Updated the documentation
-   [ ] Added tests to cover changes
-   [ ] All new and existing tests passed
