### PR TITLE
Refactoring and addressing review comments

### DIFF
--- a/src/charts/line/line.js
+++ b/src/charts/line/line.js
@@ -9,6 +9,7 @@ import { scaleOrdinal, scaleTime, scaleLinear, scaleLog } from 'd3-scale';
 import { line } from 'd3-shape';
 import { select, mouse, touch } from 'd3-selection';
 import 'd3-transition';
+import { path } from 'd3-path';
 
 import { exportChart } from '../helpers/export';
 import colorHelper from '../helpers/color';
@@ -224,7 +225,8 @@ export default function module() {
         isAnimated = false,
         ease = easeQuadInOut,
         animationDuration = motion.duration,
-        maskingRectangle,
+        strokeDashoffset = 10,
+        strokeDasharrayOffset = 3,
         lineCurve = 'linear',
         dataByTopic,
         dataSorted,
@@ -295,7 +297,7 @@ export default function module() {
             drawAxis();
             buildGradient();
             drawLines();
-            createMaskingClip();
+            animateLine();
 
             if (shouldShowTooltip()) {
                 drawHoverOverlay();
@@ -696,23 +698,19 @@ export default function module() {
      *
      * @return {void}
      */
-    function createMaskingClip() {
+    function animateLine() {
         if (isAnimated) {
-            // We use a white rectangle to simulate the line drawing animation
-            maskingRectangle = svg
-                .append('rect')
-                .attr('class', 'masking-rectangle')
-                .attr('width', width)
-                .attr('height', height)
-                .attr('x', 0)
-                .attr('y', 0);
-
-            maskingRectangle
+            const totalLength = paths.node().getTotalLength();
+            paths
+                .attr(
+                    'stroke-dasharray',
+                    totalLength + ' ' + strokeDasharrayOffset * totalLength
+                )
+                .attr('stroke-dashoffset', totalLength)
                 .transition()
                 .duration(animationDuration)
                 .ease(ease)
-                .attr('x', width)
-                .on('end', () => maskingRectangle.remove());
+                .attr('stroke-dashoffset', strokeDashoffset);
         }
     }
 


### PR DESCRIPTION
fix-Line chart animation

## Description
Animation is changed from masking to a line re-trace
Removed reference to createMaskingClip() and its dependencies. Also, refactored some magic numbers

## Motivation and Context
Better animation and refactoring based on review comments

## How Has This Been Tested?

Tested locally along with regression testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->

-   [ ] Latest master code has been merged into this branch
-   [ ] No commented out code (if required, place // TODO above with explanation)
-   [ ] No linting issues
-   [ ] Build is successful
-   [ ] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [ ] Updated the documentation
-   [ ] Added tests to cover changes
-   [ ] All new and existing tests passed
