### PR TITLE
Chore: refactor stacked-area, line, and scatterplot charts to add grid helper

### DIFF
--- a/src/charts/line/line.spec.js
+++ b/src/charts/line/line.spec.js
@@ -175,7 +175,7 @@ describe('Line Chart', () => {
                     it('should draw horizontal grid lines', () => {
                         const expected = 1;
                         const actual = containerFixture
-                            .select('.horizontal-grid-line')
+                            .select('.horizontal .grid-line')
                             .size();
 
                         expect(actual).toEqual(expected);
@@ -184,7 +184,7 @@ describe('Line Chart', () => {
                     it('should not draw vertical grid lines', () => {
                         const expected = 0;
                         const actual = containerFixture
-                            .select('.vertical-grid-line')
+                            .select('.vertical .grid-line')
                             .size();
 
                         expect(actual).toEqual(expected);
@@ -204,7 +204,7 @@ describe('Line Chart', () => {
                     it('should not draw horizontal grid lines', () => {
                         const expected = 0;
                         const actual = containerFixture
-                            .select('.horizontal-grid-line')
+                            .select('.horizontal .grid-line')
                             .size();
 
                         expect(actual).toEqual(expected);
@@ -213,7 +213,7 @@ describe('Line Chart', () => {
                     it('should draw vertical grid lines', () => {
                         const expected = 1;
                         const actual = containerFixture
-                            .select('.vertical-grid-line')
+                            .select('.vertical .grid-line')
                             .size();
 
                         expect(actual).toEqual(expected);
@@ -233,7 +233,7 @@ describe('Line Chart', () => {
                     it('should draw horizontal grid lines', () => {
                         const expected = 1;
                         const actual = containerFixture
-                            .select('.horizontal-grid-line')
+                            .select('.horizontal .grid-line')
                             .size();
 
                         expect(actual).toEqual(expected);
@@ -242,7 +242,7 @@ describe('Line Chart', () => {
                     it('should draw vertical grid lines', () => {
                         const expected = 1;
                         const actual = containerFixture
-                            .select('.vertical-grid-line')
+                            .select('.vertical .grid-line')
                             .size();
 
                         expect(actual).toEqual(expected);
@@ -543,10 +543,10 @@ describe('Line Chart', () => {
                     it('0-axis is highlighted with an additional class', () => {
                         let values = dataset.data.map((d) => d.value);
                         let minValue = Math.min(...values);
-                        let indexOf0 = -minValue;
+                        let indexOf0 = -minValue - 1;
 
                         let horizontalGridLines = d3
-                            .selectAll('.horizontal-grid-line')
+                            .selectAll('.horizontal .grid-line')
                             .filter((_, i) => i === indexOf0);
                         let classes = horizontalGridLines
                             .attr('class')

--- a/src/charts/scatter-plot/scatter-plot.js
+++ b/src/charts/scatter-plot/scatter-plot.js
@@ -21,6 +21,7 @@ import {
 import { calcLinearRegression } from '../helpers/number';
 import { setDefaultLocale } from '../helpers/locale';
 import { motion } from '../helpers/constants';
+import { gridHorizontal, gridVertical } from '../helpers/grid';
 
 /**
  * @typedef ScatterPlotData
@@ -564,17 +565,32 @@ export default function module() {
      * @private
      */
     function drawVerticalGridLines() {
-        maskGridLines = svg
+        const grid = gridVertical(xScale)
+            .range([0, chartHeight])
+            .hideEdges('first')
+            .ticks(xTicks);
+
+        grid(svg.select('.grid-lines-group'));
+
+        drawVerticalExtendedLine();
+    }
+
+    /**
+     * Draws a vertical line to extend y-axis till the edges
+     * @return {void}
+     */
+    function drawVerticalExtendedLine() {
+        baseLine = svg
             .select('.grid-lines-group')
-            .selectAll('line.vertical-grid-line')
-            .data(xScale.ticks(xTicks))
+            .selectAll('line.extended-y-line')
+            .data([0])
             .enter()
             .append('line')
-            .attr('class', 'vertical-grid-line')
-            .attr('y1', xAxisPadding.left)
+            .attr('class', 'extended-y-line')
+            .attr('y1', xAxisPadding.bottom)
             .attr('y2', chartHeight)
-            .attr('x1', (d) => xScale(d))
-            .attr('x2', (d) => xScale(d));
+            .attr('x1', 0)
+            .attr('x2', 0);
     }
 
     /**
@@ -690,7 +706,7 @@ export default function module() {
      * @private
      */
     function drawGridLines() {
-        svg.select('.grid-lines-group').selectAll('line').remove();
+        svg.select('.grid-lines-group').selectAll('grid').remove();
 
         if (grid === 'horizontal' || grid === 'full') {
             drawHorizontalGridLines();
@@ -699,8 +715,6 @@ export default function module() {
         if (grid === 'vertical' || grid === 'full') {
             drawVerticalGridLines();
         }
-
-        drawHorizontalExtendedLine();
     }
 
     /**
@@ -725,22 +739,18 @@ export default function module() {
     /**
      * Draw horizontal gridles of the chart
      * These gridlines are parallel to x-axis
-     * TODO: Refactor into new grid helper
      * @return {void}
      * @private
      */
     function drawHorizontalGridLines() {
-        maskGridLines = svg
-            .select('.grid-lines-group')
-            .selectAll('line.horizontal-grid-line')
-            .data(yScale.ticks(yTicks))
-            .enter()
-            .append('line')
-            .attr('class', 'horizontal-grid-line')
-            .attr('x1', xAxisPadding.left)
-            .attr('x2', chartWidth)
-            .attr('y1', (d) => yScale(d))
-            .attr('y2', (d) => yScale(d));
+        const grid = gridHorizontal(yScale)
+            .range([0, chartWidth])
+            .hideEdges('first')
+            .ticks(yTicks);
+
+        grid(svg.select('.grid-lines-group'));
+
+        drawHorizontalExtendedLine();
     }
 
     /**

--- a/src/charts/scatter-plot/scatter-plot.spec.js
+++ b/src/charts/scatter-plot/scatter-plot.spec.js
@@ -129,7 +129,7 @@ describe('Scatter Plot', () => {
             it('should render horizontal grid lines', () => {
                 const expected = 1;
                 const actual = containerFixture
-                    .select('.horizontal-grid-line')
+                    .select('g.grid.horizontal')
                     .size();
 
                 expect(actual).toEqual(expected);
@@ -138,18 +138,18 @@ describe('Scatter Plot', () => {
             it('should render vertical grid lines', () => {
                 const expected = 1;
                 const actual = containerFixture
-                    .select('.vertical-grid-line')
+                    .select('g.grid.vertical')
                     .size();
 
                 expect(actual).toEqual(expected);
             });
 
-            it('should render as many gridlines as number of ticks', () => {
+            it('should render one less gridline than the number of ticks', () => {
                 const actualVerticalN = containerFixture
-                    .selectAll('.grid-lines-group .vertical-grid-line')
+                    .selectAll('.grid.vertical .grid-line')
                     .size();
                 const actualHorizontalN = containerFixture
-                    .selectAll('.grid-lines-group .horizontal-grid-line')
+                    .selectAll('.grid.horizontal .grid-line')
                     .size();
                 const expectedXticks = containerFixture
                     .selectAll('.x-axis-group .tick')
@@ -158,8 +158,8 @@ describe('Scatter Plot', () => {
                     .selectAll('.y-axis-group .tick')
                     .size();
 
-                expect(actualVerticalN).toBe(expectedXticks);
-                expect(actualHorizontalN).toBe(expectedYticks);
+                expect(actualVerticalN).toBe(expectedXticks - 1);
+                expect(actualHorizontalN).toBe(expectedYticks - 1);
             });
         });
 

--- a/src/charts/stacked-area/stacked-area.spec.js
+++ b/src/charts/stacked-area/stacked-area.spec.js
@@ -133,10 +133,10 @@ describe('Stacked Area Chart', () => {
 
                 it('should render the horizontal grid lines', () => {
                     expect(
-                        containerFixture.select('.horizontal-grid-line').empty()
+                        containerFixture.select('g.grid.horizontal').empty()
                     ).toBeFalsy();
                     expect(
-                        containerFixture.select('.vertical-grid-line').empty()
+                        containerFixture.select('g.grid.vertical').empty()
                     ).toBeTruthy();
                 });
 
@@ -204,10 +204,10 @@ describe('Stacked Area Chart', () => {
 
                 it('should render the vertical grid lines', () => {
                     expect(
-                        containerFixture.select('.horizontal-grid-line').empty()
+                        containerFixture.select('g.grid.horizontal').empty()
                     ).toBeTruthy();
                     expect(
-                        containerFixture.select('.vertical-grid-line').empty()
+                        containerFixture.select('g.grid.vertical').empty()
                     ).toBeFalsy();
                 });
             });
@@ -225,10 +225,10 @@ describe('Stacked Area Chart', () => {
 
                 it('should render the vertical grid lines', () => {
                     expect(
-                        containerFixture.select('.horizontal-grid-line').empty()
+                        containerFixture.select('g.grid.horizontal').empty()
                     ).toBeFalsy();
                     expect(
-                        containerFixture.select('.vertical-grid-line').empty()
+                        containerFixture.select('g.grid.vertical').empty()
                     ).toBeFalsy();
                 });
             });


### PR DESCRIPTION
## Description

Refactor stacked area, line, and scatterplot charts to add grid helper. 

## Motivation and Context

Continues the work started in this pull request: https://github.com/britecharts/britecharts/pull/960
Addresses #947 

## How Has This Been Tested?
Standard test suite. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Refactor (changes the way we code something without changing its functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [X] Latest master code has been merged into this branch
-   [X] No commented out code (if required, place // TODO above with explanation)
-   [X] No linting issues
-   [X] Build is successful
-   [X] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [X] Updated the documentation
-   [X] Added tests to cover changes
-   [X] All new and existing tests passed
