### PR TITLE
hasCenterLegend to hide/show center legend

### DIFF
--- a/src/charts/donut/donut.js
+++ b/src/charts/donut/donut.js
@@ -758,6 +758,23 @@ export default function module() {
     };
 
     /**
+     * Gets or Sets the hasCenterLegend property of the chart, making it display
+     * legend at the center of the donut.
+     *
+     * @param  {boolean} _x         If we want to show legent at the center of the donut
+     * @return {boolean | Module}   Current hasCenterLegend flag or Chart module
+     * @public
+     */
+    exports.hasCenterLegend = function (_x) {
+        if (!arguments.length) {
+            return hasCenterLegend;
+        }
+        hasCenterLegend = _x;
+
+        return this;
+    };
+
+    /**
      * Gets or Sets the hasHoverAnimation property of the chart. By default,
      * donut chart highlights the hovered slice. This property explicitly
      * disables this hover behavior.
@@ -991,23 +1008,6 @@ export default function module() {
             return width;
         }
         width = _x;
-
-        return this;
-    };
-
-    /**
-     * Gets or Sets the hasCenterLegend property of the chart, making it display
-     * legend at the center of the donut.
-     *
-     * @param  {boolean} _x         If we want to show legent at the center of the donut
-     * @return {boolean | Module}   Current hasCenterLegend flag or Chart module
-     * @public
-     */
-    exports.hasCenterLegend = function (_x) {
-        if (!arguments.length) {
-            return hasCenterLegend;
-        }
-        hasCenterLegend = _x;
 
         return this;
     };

--- a/src/charts/donut/donut.js
+++ b/src/charts/donut/donut.js
@@ -101,6 +101,7 @@ export default function module() {
         percentageLabel = 'percentage',
         percentageFormat = '.1f',
         numberFormat,
+        hasCenterLegend = true,
         // colors
         colorScale,
         nameToColorMap = null,
@@ -340,7 +341,7 @@ export default function module() {
      * @private
      */
     function drawLegend(obj) {
-        if (obj.data) {
+        if (obj.data && hasCenterLegend) {
             svg.select('.donut-text')
                 .text(() => centeredTextFunction(obj.data))
                 .attr('dy', '.2em')
@@ -990,6 +991,23 @@ export default function module() {
             return width;
         }
         width = _x;
+
+        return this;
+    };
+
+    /**
+     * Gets or Sets the hasCenterLegend property of the chart, making it display
+     * legend at the center of the donut.
+     *
+     * @param  {boolean} _x         If we want to show legent at the center of the donut
+     * @return {boolean | Module}   Current hasCenterLegend flag or Chart module
+     * @public
+     */
+    exports.hasCenterLegend = function (_x) {
+        if (!arguments.length) {
+            return hasCenterLegend;
+        }
+        hasCenterLegend = _x;
 
         return this;
     };

--- a/src/charts/donut/donut.spec.js
+++ b/src/charts/donut/donut.spec.js
@@ -641,6 +641,18 @@ donutDataSets.forEach((datasetName) => {
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
             });
+
+            it('should provide hasCenterLegend getter and setter', () => {
+                let previous = donutChart.hasCenterLegend(),
+                    expected = false,
+                    actual;
+
+                donutChart.hasCenterLegend(expected);
+                actual = donutChart.hasCenterLegend();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
         });
 
         describe('Lifecycle', () => {

--- a/src/charts/donut/donut.spec.js
+++ b/src/charts/donut/donut.spec.js
@@ -368,9 +368,9 @@ donutDataSets.forEach((datasetName) => {
                     let actualLabel;
                     let actualValue;
 
-                    donutChart.centeredTextFunction(
-                        (d) => `${d.id} ${d.quantity}`
-                    );
+                    donutChart
+                        .centeredTextFunction((d) => `${d.id} ${d.quantity}`)
+                        .hasCenterLegend(true);
                     donutChart.highlightSliceById(11);
                     containerFixture.datum(dataset).call(donutChart);
 
@@ -454,6 +454,18 @@ donutDataSets.forEach((datasetName) => {
 
                 donutChart.externalRadius(expected);
                 actual = donutChart.externalRadius();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide hasCenterLegend getter and setter', () => {
+                let previous = donutChart.hasCenterLegend(),
+                    expected = false,
+                    actual;
+
+                donutChart.hasCenterLegend(expected);
+                actual = donutChart.hasCenterLegend();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
@@ -637,18 +649,6 @@ donutDataSets.forEach((datasetName) => {
 
                 donutChart.width(expected);
                 actual = donutChart.width();
-
-                expect(previous).not.toBe(expected);
-                expect(actual).toBe(expected);
-            });
-
-            it('should provide hasCenterLegend getter and setter', () => {
-                let previous = donutChart.hasCenterLegend(),
-                    expected = false,
-                    actual;
-
-                donutChart.hasCenterLegend(expected);
-                actual = donutChart.hasCenterLegend();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);

--- a/src/charts/line/line.js
+++ b/src/charts/line/line.js
@@ -9,6 +9,7 @@ import { scaleOrdinal, scaleTime, scaleLinear, scaleLog } from 'd3-scale';
 import { line } from 'd3-shape';
 import { select, mouse, touch } from 'd3-selection';
 import 'd3-transition';
+import { path } from 'd3-path';
 
 import { exportChart } from '../helpers/export';
 import colorHelper from '../helpers/color';
@@ -224,7 +225,8 @@ export default function module() {
         isAnimated = false,
         ease = easeQuadInOut,
         animationDuration = motion.duration,
-        maskingRectangle,
+        strokeDashoffset = 10,
+        strokeDasharrayOffset = 3,
         lineCurve = 'linear',
         dataByTopic,
         dataSorted,
@@ -295,7 +297,7 @@ export default function module() {
             drawAxis();
             buildGradient();
             drawLines();
-            createMaskingClip();
+            animateLine();
 
             if (shouldShowTooltip()) {
                 drawHoverOverlay();
@@ -696,23 +698,19 @@ export default function module() {
      *
      * @return {void}
      */
-    function createMaskingClip() {
+    function animateLine() {
         if (isAnimated) {
-            // We use a white rectangle to simulate the line drawing animation
-            maskingRectangle = svg
-                .append('rect')
-                .attr('class', 'masking-rectangle')
-                .attr('width', width)
-                .attr('height', height)
-                .attr('x', 0)
-                .attr('y', 0);
-
-            maskingRectangle
+            const totalLength = paths.node().getTotalLength();
+            paths
+                .attr(
+                    'stroke-dasharray',
+                    totalLength + ' ' + strokeDasharrayOffset * totalLength
+                )
+                .attr('stroke-dashoffset', totalLength)
                 .transition()
                 .duration(animationDuration)
                 .ease(ease)
-                .attr('x', width)
-                .on('end', () => maskingRectangle.remove());
+                .attr('stroke-dashoffset', strokeDashoffset);
         }
     }
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
    fix – Fixes an unexpected problem or unintended behavior
    feat – Adds a new feature
    chore – A regular maintenance chore or task, including: refactors, build system, CI, performance improvements
    docs – A documentation improvement task
-->

fix - Lengthy names are breaking the Donut Chart and the legend

## Description

Introduces a new attribute hasCenterLegend  which is used to show/hide center legend

## Motivation and Context

hasCenterLegend  can be used to show/hide center legend in case the length of legend is too long. It can be complemented with displaying the whole text inside a mini-tooltip

## How Has This Been Tested?

Additional unit test has been added. Tested locally along with regression testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->

-   [ ] Latest master code has been merged into this branch
-   [ ] No commented out code (if required, place // TODO above with explanation)
-   [ ] No linting issues
-   [ ] Build is successful
-   [ ] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [ ] Updated the documentation
-   [ ] Added tests to cover changes
-   [ ] All new and existing tests passed
