### PR TITLE
fix: step loading and stracked and grouped bar charts tooltip issue mitigation

### DIFF
--- a/src/charts/grouped-bar/grouped-bar.js
+++ b/src/charts/grouped-bar/grouped-bar.js
@@ -176,9 +176,10 @@ export default function module() {
      */
     function addMouseEvents() {
         if (shouldShowTooltip()) {
-            svg.on('mouseover', function (d) {
-                handleMouseOver(this, d);
-            })
+            svg.select('.chart-group')
+                .on('mouseover', function (d) {
+                    handleMouseOver(this, d);
+                })
                 .on('mouseout', function (d) {
                     handleMouseOut(this, d);
                 })

--- a/src/charts/grouped-bar/grouped-bar.spec.js
+++ b/src/charts/grouped-bar/grouped-bar.spec.js
@@ -295,7 +295,9 @@ describe('Grouped Bar Chart', () => {
 
         describe('when hovering', () => {
             it('mouseover should trigger a callback', () => {
-                const chart = containerFixture.selectAll('.grouped-bar');
+                const chart = containerFixture.selectAll(
+                    '.grouped-bar .chart-group'
+                );
                 const callbackSpy = jasmine.createSpy('callback');
                 const expectedCalls = 1;
                 const expectedArguments = 2;
@@ -312,7 +314,9 @@ describe('Grouped Bar Chart', () => {
             });
 
             it('mouseout should trigger a callback', () => {
-                const chart = containerFixture.selectAll('.grouped-bar');
+                const chart = containerFixture.selectAll(
+                    '.grouped-bar .chart-group'
+                );
                 const callbackSpy = jasmine.createSpy('callback');
                 const expectedCalls = 1;
                 const expectedArguments = 2;

--- a/src/charts/stacked-bar/stacked-bar.js
+++ b/src/charts/stacked-bar/stacked-bar.js
@@ -176,9 +176,10 @@ export default function module() {
      */
     function addMouseEvents() {
         if (shouldShowTooltip()) {
-            svg.on('mouseover', function (d) {
-                handleMouseOver(this, d);
-            })
+            svg.select('.chart-group')
+                .on('mouseover', function (d) {
+                    handleMouseOver(this, d);
+                })
                 .on('mouseout', function (d) {
                     handleMouseOut(this, d);
                 })

--- a/src/charts/stacked-bar/stacked-bar.spec.js
+++ b/src/charts/stacked-bar/stacked-bar.spec.js
@@ -295,7 +295,9 @@ describe('Stacked Bar Chart', () => {
 
         describe('when hovering', () => {
             it('mouseover should trigger a callback', () => {
-                const chart = containerFixture.selectAll('.stacked-bar');
+                const chart = containerFixture.selectAll(
+                    '.stacked-bar .chart-group'
+                );
                 const callbackSpy = jasmine.createSpy('callback');
                 const expectedCallCount = 1;
                 const expectedArgumentsCount = 2;
@@ -310,7 +312,9 @@ describe('Stacked Bar Chart', () => {
             });
 
             it('mouseout should trigger a callback', () => {
-                const chart = containerFixture.selectAll('.stacked-bar');
+                const chart = containerFixture.selectAll(
+                    '.stacked-bar .chart-group'
+                );
                 const callbackSpy = jasmine.createSpy('callback');
                 const expectedCallCount = 1;
                 const expectedArgumentsCount = 2;

--- a/src/charts/step/step.js
+++ b/src/charts/step/step.js
@@ -8,7 +8,7 @@ import { select, mouse } from 'd3-selection';
 import 'd3-transition';
 
 import { exportChart } from '../helpers/export';
-import { lineLoadingMarkup } from '../helpers/load';
+import { barLoadingMarkup } from '../helpers/load';
 
 /**
  * @typedef StepChartData
@@ -287,7 +287,7 @@ export default function module() {
      * @private
      */
     function drawLoadingState() {
-        svg.select('.loading-state-group').html(lineLoadingMarkup);
+        svg.select('.loading-state-group').html(barLoadingMarkup);
     }
 
     /**


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
    fix – Fixes an unexpected problem or unintended behavior
    feat – Adds a new feature
    chore – A regular maintenance chore or task, including: refactors, build system, CI, performance improvements
    docs – A documentation improvement task
-->

## Description
Fixes step loading shape
Adjusts tooltips on grouped and stacked bar chart
<!--- Describe your changes in detail -->

## Motivation and Context
Mitigates issue on https://github.com/britecharts/britecharts/issues/644
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit and manually
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->

-   [ ] Latest master code has been merged into this branch
-   [ ] No commented out code (if required, place // TODO above with explanation)
-   [ ] No linting issues
-   [ ] Build is successful
-   [ ] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [ ] Updated the documentation
-   [ ] Added tests to cover changes
-   [ ] All new and existing tests passed
