### PR TITLE
fix: make the composed Storybook work locally (S10)

### DIFF
--- a/.changeset/composed-storybook-local.md
+++ b/.changeset/composed-storybook-local.md
@@ -1,0 +1,13 @@
+---
+'@britecharts/react': patch
+---
+
+Fix the React Storybook preview crashing on load.
+
+`.storybook/main.js` adds a babel-loader rule so Storybook's nested React preset
+does not leave JSX unparsed. It was scoped with `exclude: /node_modules/`, which
+also swept in `storybook-stories.js` — the entry module Storybook generates at
+the root of the package. That entry is `async`, this package's babel config sets
+`forceAllTransforms`, and nothing loads `regeneratorRuntime`, so the preview died
+with `ReferenceError: regeneratorRuntime is not defined` before a single story
+rendered. The rule is now scoped by `include` to this package's own sources.

--- a/package.json
+++ b/package.json
@@ -322,7 +322,7 @@
     "demos:core": "yarn workspace @britecharts/core run demo",
     "demos:demos": "concurrently -k -n core,react,shell -c cyan,magenta,green \"yarn run demos:core\" \"yarn run demos:react\" \"yarn run demos:shell\"",
     "demos:react": "yarn workspace @britecharts/react run demo",
-    "demos:shell": "yarn workspace @britecharts/demos run demo",
+    "demos:shell": "node scripts/wait-for-storybook-refs.js http://localhost:2001/iframe.html http://localhost:2002/iframe.html -- yarn workspace @britecharts/demos run demo",
     "docs": "yarn workspace @britecharts/docs start",
     "docs:build": "yarn workspace @britecharts/docs build",
     "format": "prettier --loglevel warn --write \"**/*.js\"",

--- a/packages/core/.storybook/main.js
+++ b/packages/core/.storybook/main.js
@@ -20,7 +20,6 @@ module.exports = {
         getAbsolutePath('@storybook/addon-essentials'),
         getAbsolutePath('@storybook/addon-a11y'),
         getAbsolutePath('@storybook/addon-links'),
-        getAbsolutePath('@storybook/addon-interactions'),
     ],
     docs: {
         autodocs: 'tag',

--- a/packages/core/.storybook/middleware.js
+++ b/packages/core/.storybook/middleware.js
@@ -1,0 +1,3 @@
+// Storybook composition fetches this Storybook from the shell's origin; see the
+// shared middleware for why the wildcard CORS header is not enough.
+module.exports = require('../../../scripts/storybook-cors');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,6 @@
     "@babel/core": "^7.17.5",
     "@storybook/addon-a11y": "8.6.14",
     "@storybook/addon-essentials": "8.6.14",
-    "@storybook/addon-interactions": "8.6.14",
     "@storybook/addon-links": "8.6.14",
     "@storybook/html-webpack5": "8.6.14",
     "@storybook/manager-api": "8.6.14",
@@ -131,7 +130,7 @@
     "lint": "yarn run lint:js && yarn run lint:styles",
     "prebuild": "yarn run clean",
     "start": "yarn run demo",
-    "storybook": "storybook dev -p 2001",
+    "storybook": "storybook dev -p 2001 --exact-port",
     "test:watch": "jest --watch --colors",
     "test": "jest --colors --coverage"
   },

--- a/packages/demos/.storybook/main.js
+++ b/packages/demos/.storybook/main.js
@@ -20,7 +20,6 @@ module.exports = {
         getAbsolutePath('@storybook/addon-essentials'),
         getAbsolutePath('@storybook/addon-a11y'),
         getAbsolutePath('@storybook/addon-links'),
-        getAbsolutePath('@storybook/addon-interactions'),
     ],
     docs: {
         autodocs: 'tag',

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -6,7 +6,6 @@
     "@babel/core": "^7.17.5",
     "@storybook/addon-a11y": "8.6.14",
     "@storybook/addon-essentials": "8.6.14",
-    "@storybook/addon-interactions": "8.6.14",
     "@storybook/addon-links": "8.6.14",
     "@storybook/html-webpack5": "8.6.14",
     "@storybook/manager-api": "8.6.14",
@@ -26,6 +25,6 @@
     "demo": "yarn storybook",
     "prebuild": "yarn run clean",
     "start": "yarn storybook",
-    "storybook": "storybook dev -p 2000"
+    "storybook": "storybook dev -p 2000 --exact-port"
   }
 }

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -20,7 +20,6 @@ module.exports = {
         getAbsolutePath('@storybook/addon-essentials'),
         getAbsolutePath('@storybook/addon-a11y'),
         getAbsolutePath('@storybook/addon-links'),
-        getAbsolutePath('@storybook/addon-interactions'),
     ],
     docs: {
         autodocs: 'tag',
@@ -40,9 +39,21 @@ module.exports = {
         // export-order loaders applied, so JSX fails to parse. Declaring the
         // rule here compiles them with this package's own babel config,
         // whatever Yarn does with the hoisting.
+        //
+        // It is scoped by `include` rather than `exclude: /node_modules/`, and
+        // that matters: Storybook generates its entry module, storybook-stories.js,
+        // at the root of this package, so a node_modules-only exclusion sweeps it
+        // in too. That entry is `async`, this package's babel config sets
+        // `forceAllTransforms`, and nothing loads regeneratorRuntime -- so
+        // compiling it crashed the whole preview with `regeneratorRuntime is not
+        // defined` before a single story rendered. Storybook's own entry is
+        // Storybook's to compile.
         config.module.rules.push({
             test: /\.[jt]sx?$/,
-            exclude: /node_modules/,
+            include: [
+                path.resolve(__dirname, '../src'),
+                path.resolve(__dirname),
+            ],
             use: {
                 loader: require.resolve('babel-loader'),
                 options: {

--- a/packages/react/.storybook/middleware.js
+++ b/packages/react/.storybook/middleware.js
@@ -1,0 +1,3 @@
+// Storybook composition fetches this Storybook from the shell's origin; see the
+// shared middleware for why the wildcard CORS header is not enough.
+module.exports = require('../../../scripts/storybook-cors');

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,6 @@
     "@mdx-js/react": "^1.6.22",
     "@storybook/addon-a11y": "8.6.14",
     "@storybook/addon-essentials": "8.6.14",
-    "@storybook/addon-interactions": "8.6.14",
     "@storybook/addon-links": "8.6.14",
     "@storybook/manager-api": "8.6.14",
     "@storybook/react-webpack5": "8.6.14",
@@ -65,7 +64,7 @@
     "demo": "yarn run storybook",
     "prebuild": "yarn run clean",
     "start": "webpack-dev-server --env=test --open --hot",
-    "storybook": "storybook dev -p 2002",
+    "storybook": "storybook dev -p 2002 --exact-port",
     "test:watch": "jest --watch --colors",
     "test": "jest --colors --coverage"
   },

--- a/scripts/storybook-cors.js
+++ b/scripts/storybook-cors.js
@@ -1,0 +1,58 @@
+/**
+ * Credential-safe CORS for a composed Storybook's referenced servers.
+ *
+ * The composing Storybook (packages/demos, port 2000) fetches each ref's
+ * index.json from the browser. It sends that request with
+ * `credentials: 'include'` whenever the ref is not marked `server-checked` --
+ * which happens whenever the shell's own dev server could not reach the ref at
+ * startup, so the shell fell back to letting the browser do the checking.
+ *
+ * Storybook's dev server answers with `Access-Control-Allow-Origin: *`, and the
+ * CORS spec forbids the wildcard on a credentialed request: the server has to
+ * name the origin and opt in with `Access-Control-Allow-Credentials`. So the
+ * fetch is blocked and the sidebar shows "Oh no! Something went wrong loading
+ * this Storybook" for that ref.
+ *
+ * Storybook loads `<configDir>/middleware.js` after its own CORS middleware, so
+ * naming the origin here overrides the wildcard. Only loopback origins are
+ * echoed -- a dev server that reflected any origin *and* allowed credentials
+ * would let any page you visit read your local Storybook.
+ *
+ * This is the safety net, not the fix. The fix is starting the shell after its
+ * refs (see scripts/wait-for-storybook-refs.js), which makes them
+ * `server-checked` and drops credentials from the request entirely.
+ */
+const LOOPBACK_ORIGIN = /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+
+// The response Storybook hands the middleware is a plain Node ServerResponse,
+// not an Express one, so there is no res.vary() to append with.
+const varyOnOrigin = (res) => {
+    const current = res.getHeader('Vary');
+
+    if (!current) {
+        res.setHeader('Vary', 'Origin');
+        return;
+    }
+
+    const fields = String(current)
+        .split(',')
+        .map((field) => field.trim());
+
+    if (!fields.includes('*') && !fields.includes('Origin')) {
+        res.setHeader('Vary', [...fields, 'Origin'].join(', '));
+    }
+};
+
+module.exports = function allowCredentialedLoopbackCors(router) {
+    router.use((req, res, next) => {
+        const { origin } = req.headers;
+
+        if (origin && LOOPBACK_ORIGIN.test(origin)) {
+            res.setHeader('Access-Control-Allow-Origin', origin);
+            res.setHeader('Access-Control-Allow-Credentials', 'true');
+            varyOnOrigin(res);
+        }
+
+        next();
+    });
+};

--- a/scripts/wait-for-storybook-refs.js
+++ b/scripts/wait-for-storybook-refs.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Waits for the composed Storybook's refs to be serving, then runs its command.
+ *
+ * `yarn demos` starts core (2001), react (2002) and the composing shell (2000)
+ * at once. The shell resolves its refs once, at startup: for each one it fetches
+ * `<url>/iframe.html` from Node and records `type: 'server-checked'` if that
+ * succeeds, `'unknown'` if it does not. That decision is never revisited.
+ *
+ * A ref left at `'unknown'` is what the browser then has to check itself, and it
+ * does so with `credentials: 'include'` -- which Storybook's own
+ * `Access-Control-Allow-Origin: *` cannot satisfy, so the ref fails to load and
+ * the sidebar shows "Oh no! Something went wrong loading this Storybook". Since
+ * the shell boots at the same moment as the two Storybooks it points at, it
+ * always lost that race, and which of the two blocks broke was down to whichever
+ * webpack build happened to finish first.
+ *
+ * Waiting here makes local behave the way production already does, where the
+ * refs are Chromatic URLs that are always up.
+ *
+ * Usage: node scripts/wait-for-storybook-refs.js <url>... -- <command> [args]
+ */
+const { spawn } = require('node:child_process');
+const http = require('node:http');
+
+const TIMEOUT_MS = 5 * 60 * 1000;
+const POLL_INTERVAL_MS = 1000;
+const REQUEST_TIMEOUT_MS = 2000;
+
+const separator = process.argv.indexOf('--');
+
+if (separator === -1 || separator === process.argv.length - 1) {
+    console.error(
+        'usage: wait-for-storybook-refs.js <url>... -- <command> [args]'
+    );
+    process.exit(2);
+}
+
+const urls = process.argv.slice(2, separator);
+const [command, ...args] = process.argv.slice(separator + 1);
+
+const isUp = (url) =>
+    new Promise((resolve) => {
+        const request = http.get(url, (response) => {
+            response.resume();
+            resolve(response.statusCode === 200);
+        });
+
+        request.setTimeout(REQUEST_TIMEOUT_MS, () => request.destroy());
+        request.on('error', () => resolve(false));
+    });
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitForAll = async () => {
+    const deadline = Date.now() + TIMEOUT_MS;
+    const pending = new Set(urls);
+
+    while (pending.size > 0) {
+        const settled = await Promise.all(
+            [...pending].map(async (url) => [url, await isUp(url)])
+        );
+
+        settled
+            .filter(([, up]) => up)
+            .forEach(([url]) => {
+                pending.delete(url);
+                console.log(`[refs] ${url} is up`);
+            });
+
+        if (pending.size === 0) {
+            break;
+        }
+
+        if (Date.now() > deadline) {
+            // Start anyway rather than leave the developer with nothing: the
+            // shell still works on its own, the missing refs just will not load.
+            console.warn(
+                `[refs] gave up waiting for ${[...pending].join(', ')} after ` +
+                    `${TIMEOUT_MS / 1000}s -- starting anyway, those refs will ` +
+                    `not load`
+            );
+            break;
+        }
+
+        await wait(POLL_INTERVAL_MS);
+    }
+};
+
+waitForAll().then(() => {
+    const child = spawn(command, args, { stdio: 'inherit', shell: true });
+
+    child.on('exit', (code, signal) =>
+        signal ? process.kill(process.pid, signal) : process.exit(code ?? 0)
+    );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,7 +3337,6 @@ __metadata:
     "@babel/core": ^7.17.5
     "@storybook/addon-a11y": 8.6.14
     "@storybook/addon-essentials": 8.6.14
-    "@storybook/addon-interactions": 8.6.14
     "@storybook/addon-links": 8.6.14
     "@storybook/html-webpack5": 8.6.14
     "@storybook/manager-api": 8.6.14
@@ -3403,7 +3402,6 @@ __metadata:
     "@babel/core": ^7.17.5
     "@storybook/addon-a11y": 8.6.14
     "@storybook/addon-essentials": 8.6.14
-    "@storybook/addon-interactions": 8.6.14
     "@storybook/addon-links": 8.6.14
     "@storybook/html-webpack5": 8.6.14
     "@storybook/manager-api": 8.6.14
@@ -3446,7 +3444,6 @@ __metadata:
     "@mdx-js/react": ^1.6.22
     "@storybook/addon-a11y": 8.6.14
     "@storybook/addon-essentials": 8.6.14
-    "@storybook/addon-interactions": 8.6.14
     "@storybook/addon-links": 8.6.14
     "@storybook/manager-api": 8.6.14
     "@storybook/react-webpack5": 8.6.14
@@ -5669,21 +5666,6 @@ __metadata:
   peerDependencies:
     storybook: ^8.6.14
   checksum: 31c625deebb285350e5b79685843d19c6aecab4a2004990067877997c4bfd822252cc12838280c20b04658f8abe57b4b0932348d3b2f88134afa1313d2169125
-  languageName: node
-  linkType: hard
-
-"@storybook/addon-interactions@npm:8.6.14":
-  version: 8.6.14
-  resolution: "@storybook/addon-interactions@npm:8.6.14"
-  dependencies:
-    "@storybook/global": ^5.0.0
-    "@storybook/instrumenter": 8.6.14
-    "@storybook/test": 8.6.14
-    polished: ^4.2.2
-    ts-dedent: ^2.2.0
-  peerDependencies:
-    storybook: ^8.6.14
-  checksum: 18e94b1adc4a79405e03403824c7bbebddd0728826afc096ceb4d406a8e343fecbdd44f0d2c275adbaca4ff35462453e1c984cb65f49ec50cd5f22cda52ad588
   languageName: node
   linkType: hard
 
@@ -27732,7 +27714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-dedent@npm:^2.0.0, ts-dedent@npm:^2.2.0":
+"ts-dedent@npm:^2.0.0":
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 93ed8f7878b6d5ed3c08d99b740010eede6bccfe64bce61c5a4da06a2c17d6ddbb80a8c49c2d15251de7594a4f93ffa21dd10e7be75ef66a4dc9951b4a94e2af


### PR DESCRIPTION
The demos shell composes the core and react Storybooks as refs. Locally one of the two blocks always failed with "Oh no! Something went wrong loading this Storybook", and which one varied between runs. In production the same config works, because there the refs are Chromatic URLs that are always up.

Three separate faults, found by reading the console rather than guessing.

**The CORS error, and why it only happens locally.** The shell resolves its refs once, at startup: for each it fetches `<url>/iframe.html` from Node and records `type: 'server-checked'` if that succeeds, `'unknown'` if it does not. That decision is never revisited. A ref left `'unknown'` is one the browser has to check itself, and Storybook does that with `credentials: 'include'` -- which its own `Access-Control-Allow-Origin: *` cannot satisfy, since the CORS spec forbids the wildcard on a credentialed request. So the fetch is blocked and the ref fails to load.

`yarn demos` starts all three servers at the same moment, so the shell always lost that race, and which block broke came down to whichever webpack build finished first. `scripts/wait-for-storybook-refs.js` holds the shell until both refs answer, which makes them `server-checked` and drops credentials from the request entirely -- local now behaves the way production already does.

`scripts/storybook-cors.js`, wired in through each ref's `.storybook/ middleware.js`, is the safety net for the cases ordering cannot cover, such as starting the shell on its own: it names the requesting origin instead of the wildcard and opts in with `Access-Control-Allow-Credentials`. Only loopback origins are echoed. A dev server that reflected any origin *and* allowed credentials would let any page you visit read your local Storybook.

**The React preview never loaded at all.** Its babel-loader rule was scoped `exclude: /node_modules/`, which also caught `storybook-stories.js`, the entry Storybook generates at the root of the package. That entry is `async`, the package's babel config sets `forceAllTransforms`, and nothing loads `regeneratorRuntime` -- so the preview died with `regeneratorRuntime is not defined` before rendering a story. Now scoped by `include` to the package's own sources; Storybook's entry is Storybook's to compile.

**A taken port hung the whole runner.** `storybook dev` prompts "Port 2002 is not available, use 2003?" and waits on stdin, which under `concurrently` never arrives -- a stale server from an earlier session was enough to wedge a block indefinitely. `--exact-port` fails loudly instead, which is the right answer when the refs hardcode the ports anyway.

Also drops `@storybook/addon-interactions` from all three Storybooks. No story in the repo has a `play` function, so it did nothing but load. To be clear, it did **not** cause the CORS failure and removing it did not fix anything: the cross-origin `SecurityError` warnings it appeared to raise still occur, because `@storybook/addon-a11y` pulls in the same `@storybook/test` instrumenter. Those warnings are inherent to composition -- a composed preview is cross-origin by design -- and Storybook logs them and carries on.

Verified with a cold `yarn demos`: both refs resolve `server-checked`, both blocks populate, and stories in each render in their ref's own iframe. The `unknown` path was verified too, by starting the shell first on purpose: the credentialed fetch now returns 200 and both blocks still load.

