### PR TITLE
chore: typescript integration test

### DIFF
--- a/.changeset/typings-compile-for-consumers.md
+++ b/.changeset/typings-compile-for-consumers.md
@@ -1,0 +1,27 @@
+---
+"@britecharts/core": patch
+"@britecharts/wrappers": patch
+"@britecharts/react": patch
+---
+
+Fixes found by compiling the published typings from a TypeScript consumer
+(the new `consumers/typescript` tier), plus an `exports` map on every package.
+
+- `@britecharts/react`'s typings imported `LocalObject` from
+  `britecharts/src/typings/common/local` -- the unscoped v2 package name, so
+  they never resolved. `LocalObject` is now exported from `@britecharts/core`
+  and imported from there.
+- `@types/d3-selection` moves from core's devDependencies to its
+  dependencies: the public typings import from `d3-selection`, so TypeScript
+  consumers need those types whether or not they use d3 themselves.
+- `highlightBarFunction`'s callback was typed as returning `void | null`
+  (the `null` belonged to the callback itself), so any function that returned
+  the selection was rejected. `legend().clearHighlight()` had no return type,
+  which is an error for consumers with `noImplicitAny`. `on()` handlers were
+  typed `(...args: unknown[])`, which rejected every typed handler such as
+  `tooltip.update`; they are `any[]` now. `TooltipProps.xAxisValueType`
+  accepted `'nunber'`.
+- Each package now declares `exports`: `.` resolves types, the ES module
+  entry for bundlers (`import`) and the UMD bundle for `require`; `./dist/*`
+  and `./src/*` keep the deep paths working. For `@britecharts/react` every
+  condition points at the UMD bundle because its `src/` contains JSX.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "module": "src/index.js",
   "types": "src/typings/index.d.ts",
   "dependencies": {
+    "@types/d3-selection": "^3.0.0",
     "base-64": "^0.1.0",
     "d3-array": "^3.2.4",
     "d3-axis": "^3.0.0",
@@ -31,7 +32,6 @@
     "@storybook/html-webpack5": "8.6.14",
     "@storybook/manager-api": "8.6.14",
     "@storybook/theming": "8.6.14",
-    "@types/d3-selection": "^1.4.1",
     "@typescript-eslint/parser": "^4.6.1",
     "babel-loader": "^8.2.3",
     "babel-plugin-istanbul": "^6.0.0",
@@ -144,5 +144,16 @@
     "!**/*.stories.mdx",
     "!**/*DataBuilder.js",
     "!**/*.fixtures.js"
-  ]
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/typings/index.d.ts",
+      "import": "./src/index.js",
+      "require": "./dist/umd/bundle/core.bundled.min.js",
+      "default": "./dist/umd/bundle/core.bundled.min.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  }
 }

--- a/packages/core/src/typings/charts/bar-chart.d.ts
+++ b/packages/core/src/typings/charts/bar-chart.d.ts
@@ -58,7 +58,7 @@ export interface BarChartAPI
      * highlight effect on a bar is darkening the highlighted bar(s) color.
      */
     highlightBarFunction(
-        highlightFunc: (bar: BarSelection) => void | null
+        highlightFunc: ((bar: BarSelection) => void) | null
     ): BarChartModule;
     /** Gets or Sets the horizontal direction of the chart */
     isHorizontal(isHorizontal?: boolean): BarChartModule;

--- a/packages/core/src/typings/charts/legend-component.d.ts
+++ b/packages/core/src/typings/charts/legend-component.d.ts
@@ -44,7 +44,7 @@ export interface LegendAPI
     /**
      * Command that clears all highlighted entries on a legend instance
      */
-    clearHighlight()
+    clearHighlight(): void;
 }
 
 export type LegendModule = ChartModuleSelection<LegendDataShape[]> & LegendAPI;

--- a/packages/core/src/typings/common/base.d.ts
+++ b/packages/core/src/typings/common/base.d.ts
@@ -59,9 +59,9 @@ export interface BaseAPI<T> {
 export interface InteractiveChartAPI<T> {
     on(
         eventName: string,
-        callback: (...args: unknown[]) => void
+        callback: (...args: any[]) => void
     ): T & InteractiveChartAPI<T>;
-    on(eventName: string): (...args: unknown[]) => void;
+    on(eventName: string): (...args: any[]) => void;
 }
 
 export interface ChartDimensionsAPI<T> {

--- a/packages/core/src/typings/index.d.ts
+++ b/packages/core/src/typings/index.d.ts
@@ -12,5 +12,6 @@ export * from './charts/sparkline-chart';
 export * from './charts/stacked-area';
 export * from './charts/stacked-bar-chart';
 export * from './charts/tooltip';
+export * from './common/local';
 export * from './helpers/colors';
 export * from './helpers/constants';

--- a/packages/integration/README.md
+++ b/packages/integration/README.md
@@ -26,14 +26,22 @@ yarn test:integration     # from the repo root; needs Chromium once:
    consumer is a real project installed the way a user would install it, so
    dependency declarations are tested too, not only file contents.
 3. **Tier 1 · `tests/tarball.test.js`** — for each tarball, an allow-list of
-   globs that must be present, a deny-list that must be absent, and a check
-   that `main`, `module` and `types` point at files that exist and that no
-   `workspace:` range survived packing.
+   globs that must be present, a deny-list that must be absent, a check that
+   `main`, `module` and `types` point at files that exist and that no
+   `workspace:` range survived packing, then [publint] and [attw] with a
+   short, commented waiver list (all three waivers share one cause: the
+   packages have no `"type"` field, so Node reads the ES module sources as
+   CommonJS; real ESM output arrives with the Vite build).
 4. **Tier 2 · `tests/require.test.js`** — `require()` of the package `main`,
    every per-chart UMD build and the wrappers CommonJS bundle, resolved from
    the installed consumer. No browser, no bundler: this is what Node, Jest
    and CommonJS bundlers do.
-5. **Tier 3 · `tests/browser.spec.js`** — Playwright builds
+5. **Tier 2 · `tests/types.test.js`** — `tsc --noEmit` over
+   `consumers/typescript` under `moduleResolution: node` and `bundler`,
+   with `skipLibCheck` off so the library's own `.d.ts` files are checked.
+   Every chart factory, every React component's props, and one
+   `@ts-expect-error` per API so a typing cannot regress to `any` unnoticed.
+6. **Tier 3 · `tests/browser.spec.js`** — Playwright builds
    `consumers/vanilla` with Vite, serves it, and visits one page per
    consumption path (CDN script tags, UMD through a bundler, ES modules).
    Each page must draw the chart, have the stylesheet applied, and produce no
@@ -41,6 +49,9 @@ yarn test:integration     # from the repo root; needs Chromium once:
 
 Tiers 1 and 2 use Node's built-in test runner (`*.test.js`); tier 3 is
 Playwright (`*.spec.js`).
+
+[publint]: https://publint.dev
+[attw]: https://arethetypeswrong.github.io
 
 ## Local loop for chart work
 
@@ -69,3 +80,7 @@ build. Paths under `dist/` still come from the last installed tarball.
   esbuild consumer of the ES module entry.
 - UMD builds emitted with `window` as the global object, unloadable in Node.
 - `require('@britecharts/wrappers')` returning `undefined`.
+- The React typings importing from the unscoped v2 package name, so they
+  never resolved; `@types/d3-selection` missing from core's dependencies;
+  three typings that rejected valid calls (`on()` handlers,
+  `highlightBarFunction`, `clearHighlight`) and a `'nunber'` literal.

--- a/packages/integration/consumers/typescript/README.md
+++ b/packages/integration/consumers/typescript/README.md
@@ -1,0 +1,18 @@
+# typescript consumer
+
+Compiled, never run. `src/charts/*.ts` are the fourteen chart sandboxes from
+the old `britecharts-typescript-test-project`, pointed at `@britecharts/core`;
+`src/react/*.tsx` builds every `@britecharts/react` component with its
+required props. `tests/types.test.js` runs `tsc --noEmit` over them twice:
+
+- `tsconfig.node.json` — `moduleResolution: node`, what TS users on older
+  setups and Jest have.
+- `tsconfig.bundler.json` — `moduleResolution: bundler`, what Vite and
+  TypeScript 5 users have; this one honours the `exports` map.
+
+`skipLibCheck` is deliberately **off**: the library's own `.d.ts` files are
+the thing under test. Each file carries one `// @ts-expect-error` so a
+typing that regresses to `any` fails the build too.
+
+`@types/d3-selection` is intentionally not a dependency here: the core typings
+import from `d3-selection`, so core has to bring the types itself.

--- a/packages/integration/consumers/typescript/package.json
+++ b/packages/integration/consumers/typescript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "britecharts-typescript-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "description": "A TypeScript consumer of the published typings: every chart factory, its Module type, the colors helper, and every React component's props. Compiled, never run.",
+  "dependencies": {
+    "@britecharts/core": "file:../../.tarballs/core.tgz",
+    "@britecharts/react": "file:../../.tarballs/react.tgz",
+    "@britecharts/wrappers": "file:../../.tarballs/wrappers.tgz",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/integration/consumers/typescript/src/charts/bar.ts
+++ b/packages/integration/consumers/typescript/src/charts/bar.ts
@@ -1,0 +1,24 @@
+import { bar, colors, BarChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): BarChartModule => {
+  const barChart = bar();
+
+  barChart
+    .margin({
+      left: 120,
+      right: 20,
+      top: 20,
+      bottom: 40,
+    })
+    .hasSingleBarHighlight(false)
+    .highlightBarFunction((bar) => bar.attr('fill', 'cyan'))
+    .isHorizontal(true)
+    .hasPercentage(true)
+    .colorSchema(colors.colorSchemas.britecharts)
+    .percentageAxisToMaxRatio(1.3)
+    .width(containerNode.clientWidth)
+    .orderingFunction((a, b) => b.value - a.value)
+    .height(500);
+
+  return barChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/brush.ts
+++ b/packages/integration/consumers/typescript/src/charts/brush.ts
@@ -1,0 +1,18 @@
+import { brush, colors, BrushChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): BrushChartModule => {
+  const brushChart = brush();
+
+  brushChart
+    .margin({
+      left: 120,
+      right: 20,
+      top: 20,
+      bottom: 40,
+    })
+    .width(containerNode.clientWidth)
+    .height(500)
+    .gradient(colors.colorGradients.orangePink);
+
+  return brushChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/bullet.ts
+++ b/packages/integration/consumers/typescript/src/charts/bullet.ts
@@ -1,0 +1,9 @@
+import { bullet, BulletChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): BulletChartModule => {
+  const bulletChart = bullet();
+
+  bulletChart.width(containerNode.clientWidth).height(300);
+
+  return bulletChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/donut.ts
+++ b/packages/integration/consumers/typescript/src/charts/donut.ts
@@ -1,0 +1,18 @@
+import { donut, DonutChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): DonutChartModule => {
+  const donutChart = donut();
+
+  donutChart
+    .margin({
+      left: 120,
+      right: 20,
+      top: 20,
+      bottom: 40,
+    })
+    .width(containerNode.clientWidth)
+    .height(500)
+    .centeredTextFunction((d) => `${d.quantity} units`);
+
+  return donutChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/expect-errors.ts
+++ b/packages/integration/consumers/typescript/src/charts/expect-errors.ts
@@ -1,0 +1,50 @@
+// One wrong call per chart factory. If a typing regresses to `any`, the
+// expect-error directive below it becomes unused and tsc fails the build.
+import {
+    bar,
+    brush,
+    bullet,
+    donut,
+    groupedBar,
+    heatmap,
+    legend,
+    line,
+    miniTooltip,
+    scatterPlot,
+    sparkline,
+    stackedArea,
+    stackedBar,
+    tooltip,
+    colors,
+} from '@britecharts/core';
+
+// @ts-expect-error width takes a number
+bar().width('wide');
+// @ts-expect-error margin is an object
+brush().margin(10);
+// @ts-expect-error height takes a number
+bullet().height('tall');
+// @ts-expect-error width takes a number
+donut().width('wide');
+// @ts-expect-error isAnimated takes a boolean
+groupedBar().isAnimated('yes');
+// @ts-expect-error width takes a number
+heatmap().width('wide');
+// @ts-expect-error width takes a number
+legend().width('wide');
+// @ts-expect-error isAnimated takes a boolean
+line().isAnimated('yes');
+// @ts-expect-error not a method
+miniTooltip().nope();
+// @ts-expect-error width takes a number
+scatterPlot().width('wide');
+// @ts-expect-error width takes a number
+sparkline().width('wide');
+// @ts-expect-error width takes a number
+stackedArea().width('wide');
+// @ts-expect-error width takes a number
+stackedBar().width('wide');
+// @ts-expect-error not a method
+tooltip().nope();
+// @ts-expect-error not a colour schema
+colors.colorSchemas.nope;

--- a/packages/integration/consumers/typescript/src/charts/grouped-bar.ts
+++ b/packages/integration/consumers/typescript/src/charts/grouped-bar.ts
@@ -1,0 +1,19 @@
+import { groupedBar, colors, GroupedBarChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): GroupedBarChartModule => {
+  const groupedBarChart = groupedBar();
+
+  groupedBarChart
+    .margin({
+      left: 80,
+      right: 60,
+      top: 20,
+      bottom: 40,
+    })
+    .colorSchema(colors.colorSchemas.britecharts)
+    .width(containerNode.clientWidth)
+    .grid('horizontal')
+    .height(500);
+
+  return groupedBarChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/heatmap.ts
+++ b/packages/integration/consumers/typescript/src/charts/heatmap.ts
@@ -1,0 +1,18 @@
+import { heatmap, colors, HeatmapChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): HeatmapChartModule => {
+  const heatmapChart = heatmap();
+
+  heatmapChart
+    .margin({
+      left: 80,
+      right: 60,
+      top: 80,
+      bottom: 40,
+    })
+    .colorSchema(colors.colorSchemas.britecharts)
+    .width(containerNode.clientWidth)
+    .height(500);
+
+  return heatmapChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/legend.ts
+++ b/packages/integration/consumers/typescript/src/charts/legend.ts
@@ -1,0 +1,18 @@
+import { legend, colors, LegendModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): LegendModule => {
+  const legendComponent = legend();
+
+  legendComponent
+    .margin({
+      left: 20,
+      right: 60,
+      top: 20,
+      bottom: 0,
+    })
+    .width(containerNode.clientWidth)
+    .height(200)
+    .colorSchema(colors.colorSchemas.britecharts);
+
+  return legendComponent;
+};

--- a/packages/integration/consumers/typescript/src/charts/line-chart.ts
+++ b/packages/integration/consumers/typescript/src/charts/line-chart.ts
@@ -1,0 +1,21 @@
+import { line, LineChartModule } from '@britecharts/core';
+
+export const constructChart = (
+  containerNode: Element
+): LineChartModule => {
+  const lineChart = line();
+
+  lineChart
+    .isAnimated(true)
+    .tooltipThreshold(600)
+    .grid('horizontal')
+    .margin({ top: 60, bottom: 50, left: 50, right: 30 })
+    .yAxisLabel('Value Axis Label')
+    .on('customMouseOver', (...args: unknown[]) => {
+      console.log('customMouseOver')
+      console.log('args', args)
+    })
+    .width(containerNode.clientWidth);
+
+  return lineChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/mini-tooltip.ts
+++ b/packages/integration/consumers/typescript/src/charts/mini-tooltip.ts
@@ -1,0 +1,25 @@
+import { bar, miniTooltip, colors, BarChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): {barChart: BarChartModule, tooltip:any} => {
+  const barChart = bar();
+  const tooltip = miniTooltip();
+
+  tooltip.title('Test Title');
+
+  barChart
+    .margin({
+      left: 120,
+      right: 20,
+      top: 20,
+      bottom: 40,
+    })
+    .isHorizontal(true)
+    .colorSchema(colors.colorSchemas.britecharts)
+    .width(containerNode.clientWidth)
+    .height(500)
+    .on('customMouseOver', tooltip.show)
+    .on('customMouseMove', tooltip.update)
+    .on('customMouseOut', tooltip.hide);
+
+  return {barChart, tooltip};
+};

--- a/packages/integration/consumers/typescript/src/charts/scatter-plot.ts
+++ b/packages/integration/consumers/typescript/src/charts/scatter-plot.ts
@@ -1,0 +1,17 @@
+import { scatterPlot, ScatterPlotModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): ScatterPlotModule => {
+  const scatter = scatterPlot();
+
+  scatter
+    .width(containerNode.clientWidth)
+    .margin({bottom: 60, left: 100})
+    .hasTrendline(true)
+    .grid('horizontal')
+    .xAxisLabel('Temperature (C)')
+    .yAxisLabel('Ice Cream Sales')
+    .xAxisFormat('.1f')
+    .yAxisFormat('$');
+
+  return scatter;
+};

--- a/packages/integration/consumers/typescript/src/charts/sparkline.ts
+++ b/packages/integration/consumers/typescript/src/charts/sparkline.ts
@@ -1,0 +1,19 @@
+import { sparkline, SparklineChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): SparklineChartModule => {
+  const sparklineChart = sparkline();
+
+  sparklineChart
+    .margin({
+      left: 100,
+      right: 100,
+      top: 80,
+      bottom: 80,
+    })
+    .width(containerNode.clientWidth)
+    .height(300)
+    .isAnimated(true)
+    .animationDuration(400);
+
+  return sparklineChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/stacked-area.ts
+++ b/packages/integration/consumers/typescript/src/charts/stacked-area.ts
@@ -1,0 +1,15 @@
+import { stackedArea, StackedAreaChartModule } from '@britecharts/core';
+
+export const constructChart = (
+  containerNode: Element
+): StackedAreaChartModule => {
+  const stackedAreaChart = stackedArea();
+
+  stackedAreaChart
+    .isAnimated(true)
+    .tooltipThreshold(600)
+    .grid('full')
+    .width(containerNode.clientWidth);
+
+  return stackedAreaChart;
+};

--- a/packages/integration/consumers/typescript/src/charts/stacked-bar.ts
+++ b/packages/integration/consumers/typescript/src/charts/stacked-bar.ts
@@ -1,0 +1,23 @@
+import { stackedBar, colors, StackedBarChartModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): StackedBarChartModule => {
+  const stackedBarChart = stackedBar();
+
+  stackedBarChart
+    .margin({
+      left: 80,
+      right: 60,
+      top: 20,
+      bottom: 40,
+    })
+    .colorSchema(colors.colorSchemas.britecharts)
+    .width(containerNode.clientWidth)
+    .grid('horizontal')
+    .isAnimated(true)
+    .betweenBarsPadding(0.3)
+    .height(500);
+
+  return stackedBarChart;
+};
+
+

--- a/packages/integration/consumers/typescript/src/charts/tooltip.ts
+++ b/packages/integration/consumers/typescript/src/charts/tooltip.ts
@@ -1,0 +1,19 @@
+import { line, tooltip, LineChartModule, TooltipModule } from '@britecharts/core';
+
+export const constructChart = (containerNode: Element): {lineChartWithTooltip: LineChartModule, tooltipComponent:TooltipModule} => {
+  const lineChartWithTooltip = line();
+  const tooltipComponent = tooltip();
+
+  tooltipComponent.title('Test Title');
+
+  lineChartWithTooltip
+    .margin({top:60, bottom: 50, left: 50, right: 30})
+    .grid('horizontal')
+    .width(containerNode.clientWidth)
+    .height(500)
+    .on('customMouseOver', tooltipComponent.show)
+    .on('customMouseMove', tooltipComponent.update)
+    .on('customMouseOut', tooltipComponent.hide);
+
+  return {lineChartWithTooltip, tooltipComponent};
+};

--- a/packages/integration/consumers/typescript/src/data/bar-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/bar-sample.ts
@@ -1,0 +1,28 @@
+import { BarChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_BAR_DATA: BarChartDataShape[] = [
+  {
+    name: 'Radiating',
+    value: 0.08167,
+  },
+  {
+    name: 'Opalescent',
+    value: 0.0492,
+  },
+  {
+    name: 'Shining',
+    value: 0.02782,
+  },
+  {
+    name: 'Vibrant',
+    value: 0.04253,
+  },
+  {
+    name: 'Vivid',
+    value: 0.02702,
+  },
+  {
+    name: 'Brilliant',
+    value: 0.02288,
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/brush-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/brush-sample.ts
@@ -1,0 +1,28 @@
+import { BrushChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_BRUSH_DATA: BrushChartDataShape[] = [
+    {
+        date: "2015-06-27T07:00:00.000Z",
+        value: 4,
+    },
+    {
+        date: "2015-06-28T07:00:00.000Z",
+        value: 12,
+    },
+    {
+        date: "2015-06-29T07:00:00.000Z",
+        value: 33,
+    },
+    {
+        date: "2015-06-30T07:00:00.000Z",
+        value: 17,
+    },
+    {
+        date: "2015-07-01T07:00:00.000Z",
+        value: 17,
+    },
+    {
+        date: "2015-07-02T07:00:00.000Z",
+        value: 16,
+    },
+];

--- a/packages/integration/consumers/typescript/src/data/bullet-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/bullet-sample.ts
@@ -1,0 +1,7 @@
+import { BulletChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_BULLET_DATA: BulletChartDataShape = {
+  ranges: [130, 160, 250],
+  measures: [150, 180],
+  markers: [175],
+};

--- a/packages/integration/consumers/typescript/src/data/donut-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/donut-sample.ts
@@ -1,0 +1,22 @@
+import { DonutChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_DONUT_DATA: DonutChartDataShape[] = [
+  {
+    name: 'Shiny',
+    id: 11,
+    quantity: 200,
+    percentage: 25,
+  },
+  {
+    name: 'Radiant',
+    id: 12,
+    quantity: 0,
+    percentage: 0,
+  },
+  {
+    name: 'Sparkling',
+    id: 13,
+    quantity: 600,
+    percentage: 75,
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/grouped-bar-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/grouped-bar-sample.ts
@@ -1,0 +1,64 @@
+import { GroupedBarChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_GROUPED_BAR_DATA: GroupedBarChartDataShape[] = [
+  {
+      "name": "Shiny",
+      "value": 3,
+      "group": "2011-01-05",
+  },
+  {
+      "name": "Shiny",
+      "value": 10,
+      "group": "2011-01-06",
+  },
+  {
+      "name": "Shiny",
+      "value": 16,
+      "group": "2011-01-07",
+  },
+  {
+      "name": "Shiny",
+      "value": 23,
+      "group": "2011-01-08",
+  },
+  {
+      "name": "Radiant",
+      "value": 23,
+      "group": "2011-01-05",
+  },
+  {
+      "name": "Radiant",
+      "value": 16,
+      "group": "2011-01-06",
+  },
+  {
+      "name": "Radiant",
+      "value": 10,
+      "group": "2011-01-07",
+  },
+  {
+      "name": "Radiant",
+      "value": 4,
+      "group": "2011-01-08",
+  },
+  {
+      "name": "Luminous",
+      "value": 10,
+      "group": "2011-01-05",
+  },
+  {
+      "name": "Luminous",
+      "value": 20,
+      "group": "2011-01-06",
+  },
+  {
+      "name": "Luminous",
+      "value": 26,
+      "group": "2011-01-07",
+  },
+  {
+      "name": "Luminous",
+      "value": 33,
+      "group": "2011-01-08",
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/heatmap-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/heatmap-sample.ts
@@ -1,0 +1,844 @@
+import { HeatmapChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_HEATMAP_DATA: HeatmapChartDataShape[] = [
+  {
+      "day": 0,
+      "hour": 0,
+      "value": 7
+  },
+  {
+      "day": 0,
+      "hour": 1,
+      "value": 0
+  },
+  {
+      "day": 0,
+      "hour": 2,
+      "value": 1
+  },
+  {
+      "day": 0,
+      "hour": 3,
+      "value": 0
+  },
+  {
+      "day": 0,
+      "hour": 4,
+      "value": 0
+  },
+  {
+      "day": 0,
+      "hour": 5,
+      "value": 0
+  },
+  {
+      "day": 0,
+      "hour": 6,
+      "value": 0
+  },
+  {
+      "day": 0,
+      "hour": 7,
+      "value": 9
+  },
+  {
+      "day": 0,
+      "hour": 8,
+      "value": 7
+  },
+  {
+      "day": 0,
+      "hour": 9,
+      "value": 26
+  },
+  {
+      "day": 0,
+      "hour": 10,
+      "value": 30
+  },
+  {
+      "day": 0,
+      "hour": 11,
+      "value": 26
+  },
+  {
+      "day": 0,
+      "hour": 12,
+      "value": 19
+  },
+  {
+      "day": 0,
+      "hour": 13,
+      "value": 23
+  },
+  {
+      "day": 0,
+      "hour": 14,
+      "value": 13
+  },
+  {
+      "day": 0,
+      "hour": 15,
+      "value": 19
+  },
+  {
+      "day": 0,
+      "hour": 16,
+      "value": 22
+  },
+  {
+      "day": 0,
+      "hour": 17,
+      "value": 23
+  },
+  {
+      "day": 0,
+      "hour": 18,
+      "value": 14
+  },
+  {
+      "day": 0,
+      "hour": 19,
+      "value": 16
+  },
+  {
+      "day": 0,
+      "hour": 20,
+      "value": 19
+  },
+  {
+      "day": 0,
+      "hour": 21,
+      "value": 16
+  },
+  {
+      "day": 0,
+      "hour": 22,
+      "value": 18
+  },
+  {
+      "day": 0,
+      "hour": 23,
+      "value": 25
+  },
+  {
+      "day": 1,
+      "hour": 0,
+      "value": 6
+  },
+  {
+      "day": 1,
+      "hour": 1,
+      "value": 3
+  },
+  {
+      "day": 1,
+      "hour": 2,
+      "value": 2
+  },
+  {
+      "day": 1,
+      "hour": 3,
+      "value": 2
+  },
+  {
+      "day": 1,
+      "hour": 4,
+      "value": 6
+  },
+  {
+      "day": 1,
+      "hour": 5,
+      "value": 1
+  },
+  {
+      "day": 1,
+      "hour": 6,
+      "value": 1
+  },
+  {
+      "day": 1,
+      "hour": 7,
+      "value": 1
+  },
+  {
+      "day": 1,
+      "hour": 8,
+      "value": 14
+  },
+  {
+      "day": 1,
+      "hour": 9,
+      "value": 31
+  },
+  {
+      "day": 1,
+      "hour": 10,
+      "value": 25
+  },
+  {
+      "day": 1,
+      "hour": 11,
+      "value": 50
+  },
+  {
+      "day": 1,
+      "hour": 12,
+      "value": 35
+  },
+  {
+      "day": 1,
+      "hour": 13,
+      "value": 38
+  },
+  {
+      "day": 1,
+      "hour": 14,
+      "value": 30
+  },
+  {
+      "day": 1,
+      "hour": 15,
+      "value": 44
+  },
+  {
+      "day": 1,
+      "hour": 16,
+      "value": 31
+  },
+  {
+      "day": 1,
+      "hour": 17,
+      "value": 30
+  },
+  {
+      "day": 1,
+      "hour": 18,
+      "value": 19
+  },
+  {
+      "day": 1,
+      "hour": 19,
+      "value": 6
+  },
+  {
+      "day": 1,
+      "hour": 20,
+      "value": 14
+  },
+  {
+      "day": 1,
+      "hour": 21,
+      "value": 29
+  },
+  {
+      "day": 1,
+      "hour": 22,
+      "value": 20
+  },
+  {
+      "day": 1,
+      "hour": 23,
+      "value": 18
+  },
+  {
+      "day": 2,
+      "hour": 0,
+      "value": 13
+  },
+  {
+      "day": 2,
+      "hour": 1,
+      "value": 2
+  },
+  {
+      "day": 2,
+      "hour": 2,
+      "value": 7
+  },
+  {
+      "day": 2,
+      "hour": 3,
+      "value": 1
+  },
+  {
+      "day": 2,
+      "hour": 4,
+      "value": 0
+  },
+  {
+      "day": 2,
+      "hour": 5,
+      "value": 0
+  },
+  {
+      "day": 2,
+      "hour": 6,
+      "value": 2
+  },
+  {
+      "day": 2,
+      "hour": 7,
+      "value": 4
+  },
+  {
+      "day": 2,
+      "hour": 8,
+      "value": 29
+  },
+  {
+      "day": 2,
+      "hour": 9,
+      "value": 28
+  },
+  {
+      "day": 2,
+      "hour": 10,
+      "value": 44
+  },
+  {
+      "day": 2,
+      "hour": 11,
+      "value": 43
+  },
+  {
+      "day": 2,
+      "hour": 12,
+      "value": 33
+  },
+  {
+      "day": 2,
+      "hour": 13,
+      "value": 69
+  },
+  {
+      "day": 2,
+      "hour": 14,
+      "value": 54
+  },
+  {
+      "day": 2,
+      "hour": 15,
+      "value": 43
+  },
+  {
+      "day": 2,
+      "hour": 16,
+      "value": 49
+  },
+  {
+      "day": 2,
+      "hour": 17,
+      "value": 34
+  },
+  {
+      "day": 2,
+      "hour": 18,
+      "value": 20
+  },
+  {
+      "day": 2,
+      "hour": 19,
+      "value": 14
+  },
+  {
+      "day": 2,
+      "hour": 20,
+      "value": 13
+  },
+  {
+      "day": 2,
+      "hour": 21,
+      "value": 31
+  },
+  {
+      "day": 2,
+      "hour": 22,
+      "value": 21
+  },
+  {
+      "day": 2,
+      "hour": 23,
+      "value": 18
+  },
+  {
+      "day": 3,
+      "hour": 0,
+      "value": 11
+  },
+  {
+      "day": 3,
+      "hour": 1,
+      "value": 5
+  },
+  {
+      "day": 3,
+      "hour": 2,
+      "value": 5
+  },
+  {
+      "day": 3,
+      "hour": 3,
+      "value": 0
+  },
+  {
+      "day": 3,
+      "hour": 4,
+      "value": 1
+  },
+  {
+      "day": 3,
+      "hour": 5,
+      "value": 1
+  },
+  {
+      "day": 3,
+      "hour": 6,
+      "value": 1
+  },
+  {
+      "day": 3,
+      "hour": 7,
+      "value": 4
+  },
+  {
+      "day": 3,
+      "hour": 8,
+      "value": 22
+  },
+  {
+      "day": 3,
+      "hour": 9,
+      "value": 47
+  },
+  {
+      "day": 3,
+      "hour": 10,
+      "value": 77
+  },
+  {
+      "day": 3,
+      "hour": 11,
+      "value": 86
+  },
+  {
+      "day": 3,
+      "hour": 12,
+      "value": 54
+  },
+  {
+      "day": 3,
+      "hour": 13,
+      "value": 36
+  },
+  {
+      "day": 3,
+      "hour": 14,
+      "value": 42
+  },
+  {
+      "day": 3,
+      "hour": 15,
+      "value": 54
+  },
+  {
+      "day": 3,
+      "hour": 16,
+      "value": 40
+  },
+  {
+      "day": 3,
+      "hour": 17,
+      "value": 40
+  },
+  {
+      "day": 3,
+      "hour": 18,
+      "value": 33
+  },
+  {
+      "day": 3,
+      "hour": 19,
+      "value": 18
+  },
+  {
+      "day": 3,
+      "hour": 20,
+      "value": 28
+  },
+  {
+      "day": 3,
+      "hour": 21,
+      "value": 32
+  },
+  {
+      "day": 3,
+      "hour": 22,
+      "value": 29
+  },
+  {
+      "day": 3,
+      "hour": 23,
+      "value": 24
+  },
+  {
+      "day": 4,
+      "hour": 0,
+      "value": 16
+  },
+  {
+      "day": 4,
+      "hour": 1,
+      "value": 0
+  },
+  {
+      "day": 4,
+      "hour": 2,
+      "value": 1
+  },
+  {
+      "day": 4,
+      "hour": 3,
+      "value": 0
+  },
+  {
+      "day": 4,
+      "hour": 4,
+      "value": 0
+  },
+  {
+      "day": 4,
+      "hour": 5,
+      "value": 0
+  },
+  {
+      "day": 4,
+      "hour": 6,
+      "value": 1
+  },
+  {
+      "day": 4,
+      "hour": 7,
+      "value": 5
+  },
+  {
+      "day": 4,
+      "hour": 8,
+      "value": 19
+  },
+  {
+      "day": 4,
+      "hour": 9,
+      "value": 53
+  },
+  {
+      "day": 4,
+      "hour": 10,
+      "value": 48
+  },
+  {
+      "day": 4,
+      "hour": 11,
+      "value": 28
+  },
+  {
+      "day": 4,
+      "hour": 12,
+      "value": 39
+  },
+  {
+      "day": 4,
+      "hour": 13,
+      "value": 28
+  },
+  {
+      "day": 4,
+      "hour": 14,
+      "value": 43
+  },
+  {
+      "day": 4,
+      "hour": 15,
+      "value": 64
+  },
+  {
+      "day": 4,
+      "hour": 16,
+      "value": 32
+  },
+  {
+      "day": 4,
+      "hour": 17,
+      "value": 50
+  },
+  {
+      "day": 4,
+      "hour": 18,
+      "value": 11
+  },
+  {
+      "day": 4,
+      "hour": 19,
+      "value": 19
+  },
+  {
+      "day": 4,
+      "hour": 20,
+      "value": 18
+  },
+  {
+      "day": 4,
+      "hour": 21,
+      "value": 18
+  },
+  {
+      "day": 4,
+      "hour": 22,
+      "value": 25
+  },
+  {
+      "day": 4,
+      "hour": 23,
+      "value": 18
+  },
+  {
+      "day": 5,
+      "hour": 0,
+      "value": 9
+  },
+  {
+      "day": 5,
+      "hour": 1,
+      "value": 2
+  },
+  {
+      "day": 5,
+      "hour": 2,
+      "value": 0
+  },
+  {
+      "day": 5,
+      "hour": 3,
+      "value": 0
+  },
+  {
+      "day": 5,
+      "hour": 4,
+      "value": 0
+  },
+  {
+      "day": 5,
+      "hour": 5,
+      "value": 0
+  },
+  {
+      "day": 5,
+      "hour": 6,
+      "value": 1
+  },
+  {
+      "day": 5,
+      "hour": 7,
+      "value": 2
+  },
+  {
+      "day": 5,
+      "hour": 8,
+      "value": 14
+  },
+  {
+      "day": 5,
+      "hour": 9,
+      "value": 35
+  },
+  {
+      "day": 5,
+      "hour": 10,
+      "value": 53
+  },
+  {
+      "day": 5,
+      "hour": 11,
+      "value": 26
+  },
+  {
+      "day": 5,
+      "hour": 12,
+      "value": 25
+  },
+  {
+      "day": 5,
+      "hour": 13,
+      "value": 18
+  },
+  {
+      "day": 5,
+      "hour": 14,
+      "value": 41
+  },
+  {
+      "day": 5,
+      "hour": 15,
+      "value": 35
+  },
+  {
+      "day": 5,
+      "hour": 16,
+      "value": 42
+  },
+  {
+      "day": 5,
+      "hour": 17,
+      "value": 23
+  },
+  {
+      "day": 5,
+      "hour": 18,
+      "value": 23
+  },
+  {
+      "day": 5,
+      "hour": 19,
+      "value": 15
+  },
+  {
+      "day": 5,
+      "hour": 20,
+      "value": 18
+  },
+  {
+      "day": 5,
+      "hour": 21,
+      "value": 21
+  },
+  {
+      "day": 5,
+      "hour": 22,
+      "value": 22
+  },
+  {
+      "day": 5,
+      "hour": 23,
+      "value": 13
+  },
+  {
+      "day": 6,
+      "hour": 0,
+      "value": 24
+  },
+  {
+      "day": 6,
+      "hour": 1,
+      "value": 6
+  },
+  {
+      "day": 6,
+      "hour": 2,
+      "value": 0
+  },
+  {
+      "day": 6,
+      "hour": 3,
+      "value": 0
+  },
+  {
+      "day": 6,
+      "hour": 4,
+      "value": 0
+  },
+  {
+      "day": 6,
+      "hour": 5,
+      "value": 0
+  },
+  {
+      "day": 6,
+      "hour": 6,
+      "value": 0
+  },
+  {
+      "day": 6,
+      "hour": 7,
+      "value": 1
+  },
+  {
+      "day": 6,
+      "hour": 8,
+      "value": 10
+  },
+  {
+      "day": 6,
+      "hour": 9,
+      "value": 35
+  },
+  {
+      "day": 6,
+      "hour": 10,
+      "value": 30
+  },
+  {
+      "day": 6,
+      "hour": 11,
+      "value": 27
+  },
+  {
+      "day": 6,
+      "hour": 12,
+      "value": 34
+  },
+  {
+      "day": 6,
+      "hour": 13,
+      "value": 31
+  },
+  {
+      "day": 6,
+      "hour": 14,
+      "value": 30
+  },
+  {
+      "day": 6,
+      "hour": 15,
+      "value": 5
+  },
+  {
+      "day": 6,
+      "hour": 16,
+      "value": 12
+  },
+  {
+      "day": 6,
+      "hour": 17,
+      "value": 26
+  },
+  {
+      "day": 6,
+      "hour": 18,
+      "value": 9
+  },
+  {
+      "day": 6,
+      "hour": 19,
+      "value": 2
+  },
+  {
+      "day": 6,
+      "hour": 20,
+      "value": 3
+  },
+  {
+      "day": 6,
+      "hour": 21,
+      "value": 8
+  },
+  {
+      "day": 6,
+      "hour": 22,
+      "value": 5
+  },
+  {
+      "day": 6,
+      "hour": 23,
+      "value": 3
+  }
+];

--- a/packages/integration/consumers/typescript/src/data/legend-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/legend-sample.ts
@@ -1,0 +1,34 @@
+import { LegendDataShape } from '@britecharts/core';
+
+export const SAMPLE_LEGEND_DATA_MINIMAL: LegendDataShape[] = [
+  {
+    name: 'Shiny',
+    id: 11,
+  },
+  {
+    name: 'Radiant',
+    id: 12,
+  },
+  {
+    name: 'Sparkling',
+    id: 13,
+  },
+];
+
+export const SAMPLE_LEGEND_DATA: LegendDataShape[] = [
+  {
+    name: 'Shiny',
+    id: 11,
+    quantity: 1200,
+  },
+  {
+    name: 'Radiant',
+    id: 12,
+    quantity: 800,
+  },
+  {
+    name: 'Sparkling',
+    id: 13,
+    quantity: 1000,
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/line-chart-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/line-chart-sample.ts
@@ -1,0 +1,35 @@
+import { LineChartData } from '@britecharts/core';
+
+export const SAMPLE_LINE_CHART_DATA: LineChartData = {
+  data:[
+  {
+      "topicName": "Sales",
+      "name": "1",
+      "value": 15,
+      "date": "2015-12-30T00:00:00-08:00"
+  },
+  {
+      "topicName": "Sales",
+      "name": "1",
+      "value": 16,
+      "date": "2015-12-31T00:00:00-08:00"
+  },
+  {
+      "topicName": "Sales",
+      "name": "1",
+      "value": 15,
+      "date": "2016-01-01T00:00:00-08:00"
+  },
+  {
+      "topicName": "Sales",
+      "name": "1",
+      "value": 18,
+      "date": "2016-01-02T00:00:00-08:00"
+  },
+  {
+      "topicName": "Sales",
+      "name": "1",
+      "value": 16,
+      "date": "2016-01-03T00:00:00-08:00"
+  }
+]};

--- a/packages/integration/consumers/typescript/src/data/mini-tooltip-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/mini-tooltip-sample.ts
@@ -1,0 +1,28 @@
+import { BarChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_MINI_TOOLTIP_DATA: BarChartDataShape[] = [
+  {
+    name: 'Radiating',
+    value: 0.08167,
+  },
+  {
+    name: 'Opalescent',
+    value: 0.0492,
+  },
+  {
+    name: 'Shining',
+    value: 0.02782,
+  },
+  {
+    name: 'Vibrant',
+    value: 0.04253,
+  },
+  {
+    name: 'Vivid',
+    value: 0.02702,
+  },
+  {
+    name: 'Brilliant',
+    value: 0.02288,
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/scatter-plot-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/scatter-plot-sample.ts
@@ -1,0 +1,64 @@
+import { ScatterPlotDataShape } from '@britecharts/core';
+
+export const SAMPLE_SCATTER_PLOT_DATA: ScatterPlotDataShape[] = [
+  {
+    name: 'Ice Cream Sales',
+    x: 14.2,
+    y: 215,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 16.4,
+    y: 325,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 11.9,
+    y: 185,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 15.2,
+    y: 332,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 18.5,
+    y: 406,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 22.1,
+    y: 522,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 19.4,
+    y: 412,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 25.1,
+    y: 614,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 23.4,
+    y: 544,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 18.1,
+    y: 421,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 22.6,
+    y: 445,
+  },
+  {
+    name: 'Ice Cream Sales',
+    x: 17.2,
+    y: 408,
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/sparkline-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/sparkline-sample.ts
@@ -1,0 +1,36 @@
+import { SparklineChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_SPARKLINE_DATA: SparklineChartDataShape[] = [
+  {
+    "value": 2,
+    "date": "2011-01-05T00:00:00Z",
+  },
+  {
+    "value": 5,
+    "date": "2011-01-06T00:00:00Z",
+  },
+  {
+      "value": 16,
+      "date": "2011-01-07T00:00:00Z",
+  },
+  {
+    "value": 23,
+    "date": "2011-01-08T00:00:00Z",
+  },
+  {
+    "value": 18,
+    "date": "2011-01-09T00:00:00Z",
+  },
+  {
+    "value": 25,
+    "date": "2011-01-10T00:00:00Z",
+  },
+  {
+    "value": 28,
+    "date": "2011-01-11T00:00:00Z",
+  },
+  {
+    "value": 2,
+    "date": "2011-01-12T00:00:00Z",
+  }
+];

--- a/packages/integration/consumers/typescript/src/data/stacked-area-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/stacked-area-sample.ts
@@ -1,0 +1,1984 @@
+import { StackedAreaChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_STACKED_AREA_DATA: StackedAreaChartDataShape[] = [
+  {
+    date: '2017-08-26T07:00:00.000Z',
+    value: 906,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-26T07:00:00.000Z',
+    value: 353,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-26T07:00:00.000Z',
+    value: 300,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-26T07:00:00.000Z',
+    value: 113,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-26T07:00:00.000Z',
+    value: 103,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-26T07:00:00.000Z',
+    value: 114,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-25T07:00:00.000Z',
+    value: 906,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-25T07:00:00.000Z',
+    value: 353,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-25T07:00:00.000Z',
+    value: 240,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-25T07:00:00.000Z',
+    value: 113,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-25T07:00:00.000Z',
+    value: 103,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-25T07:00:00.000Z',
+    value: 114,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-24T07:00:00.000Z',
+    value: 902,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-24T07:00:00.000Z',
+    value: 353,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-24T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-24T07:00:00.000Z',
+    value: 113,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-24T07:00:00.000Z',
+    value: 103,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-24T07:00:00.000Z',
+    value: 114,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-23T07:00:00.000Z',
+    value: 861,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-23T07:00:00.000Z',
+    value: 343,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-23T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-23T07:00:00.000Z',
+    value: 111,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-23T07:00:00.000Z',
+    value: 102,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-23T07:00:00.000Z',
+    value: 114,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-22T07:00:00.000Z',
+    value: 800,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-22T07:00:00.000Z',
+    value: 330,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-22T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-22T07:00:00.000Z',
+    value: 102,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-22T07:00:00.000Z',
+    value: 100,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-22T07:00:00.000Z',
+    value: 104,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-21T07:00:00.000Z',
+    value: 739,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-21T07:00:00.000Z',
+    value: 328,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-21T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-21T07:00:00.000Z',
+    value: 94,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-21T07:00:00.000Z',
+    value: 100,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-21T07:00:00.000Z',
+    value: 102,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-20T07:00:00.000Z',
+    value: 691,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-20T07:00:00.000Z',
+    value: 327,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-20T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-20T07:00:00.000Z',
+    value: 91,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-20T07:00:00.000Z',
+    value: 100,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-20T07:00:00.000Z',
+    value: 96,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-19T07:00:00.000Z',
+    value: 674,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-19T07:00:00.000Z',
+    value: 326,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-19T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-19T07:00:00.000Z',
+    value: 91,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-19T07:00:00.000Z',
+    value: 96,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-19T07:00:00.000Z',
+    value: 95,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-18T07:00:00.000Z',
+    value: 659,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-18T07:00:00.000Z',
+    value: 320,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-18T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-18T07:00:00.000Z',
+    value: 84,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-18T07:00:00.000Z',
+    value: 95,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-18T07:00:00.000Z',
+    value: 91,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-17T07:00:00.000Z',
+    value: 646,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-17T07:00:00.000Z',
+    value: 314,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-17T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-17T07:00:00.000Z',
+    value: 70,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-17T07:00:00.000Z',
+    value: 95,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-17T07:00:00.000Z',
+    value: 85,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-16T07:00:00.000Z',
+    value: 625,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-16T07:00:00.000Z',
+    value: 302,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-16T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-16T07:00:00.000Z',
+    value: 69,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-16T07:00:00.000Z',
+    value: 94,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-16T07:00:00.000Z',
+    value: 81,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-15T07:00:00.000Z',
+    value: 599,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-15T07:00:00.000Z',
+    value: 293,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-15T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-15T07:00:00.000Z',
+    value: 64,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-15T07:00:00.000Z',
+    value: 94,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-15T07:00:00.000Z',
+    value: 79,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-14T07:00:00.000Z',
+    value: 583,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-14T07:00:00.000Z',
+    value: 291,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-14T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-14T07:00:00.000Z',
+    value: 64,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-14T07:00:00.000Z',
+    value: 93,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-14T07:00:00.000Z',
+    value: 79,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-13T07:00:00.000Z',
+    value: 571,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-13T07:00:00.000Z',
+    value: 291,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-13T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-13T07:00:00.000Z',
+    value: 60,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-13T07:00:00.000Z',
+    value: 93,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-13T07:00:00.000Z',
+    value: 79,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-12T07:00:00.000Z',
+    value: 562,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-12T07:00:00.000Z',
+    value: 289,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-12T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-12T07:00:00.000Z',
+    value: 60,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-12T07:00:00.000Z',
+    value: 93,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-12T07:00:00.000Z',
+    value: 78,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-11T07:00:00.000Z',
+    value: 556,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-11T07:00:00.000Z',
+    value: 287,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-11T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-11T07:00:00.000Z',
+    value: 60,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-11T07:00:00.000Z',
+    value: 90,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-11T07:00:00.000Z',
+    value: 78,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-10T07:00:00.000Z',
+    value: 544,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-10T07:00:00.000Z',
+    value: 281,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-10T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-10T07:00:00.000Z',
+    value: 59,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-10T07:00:00.000Z',
+    value: 89,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-10T07:00:00.000Z',
+    value: 78,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-09T07:00:00.000Z',
+    value: 533,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-09T07:00:00.000Z',
+    value: 276,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-09T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-09T07:00:00.000Z',
+    value: 59,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-09T07:00:00.000Z',
+    value: 89,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-09T07:00:00.000Z',
+    value: 74,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-08T07:00:00.000Z',
+    value: 523,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-08T07:00:00.000Z',
+    value: 274,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-08T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-08T07:00:00.000Z',
+    value: 59,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-08T07:00:00.000Z',
+    value: 89,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-08T07:00:00.000Z',
+    value: 73,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-07T07:00:00.000Z',
+    value: 521,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-07T07:00:00.000Z',
+    value: 271,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-07T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-07T07:00:00.000Z',
+    value: 59,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-07T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-07T07:00:00.000Z',
+    value: 73,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-06T07:00:00.000Z',
+    value: 508,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-06T07:00:00.000Z',
+    value: 271,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-06T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-06T07:00:00.000Z',
+    value: 58,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-06T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-06T07:00:00.000Z',
+    value: 73,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-05T07:00:00.000Z',
+    value: 504,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-05T07:00:00.000Z',
+    value: 267,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-05T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-05T07:00:00.000Z',
+    value: 57,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-05T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-05T07:00:00.000Z',
+    value: 73,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-04T07:00:00.000Z',
+    value: 487,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-04T07:00:00.000Z',
+    value: 267,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-04T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-04T07:00:00.000Z',
+    value: 57,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-04T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-04T07:00:00.000Z',
+    value: 73,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-03T07:00:00.000Z',
+    value: 478,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-03T07:00:00.000Z',
+    value: 265,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-03T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-03T07:00:00.000Z',
+    value: 55,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-03T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-03T07:00:00.000Z',
+    value: 73,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-02T07:00:00.000Z',
+    value: 472,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-02T07:00:00.000Z',
+    value: 264,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-02T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-02T07:00:00.000Z',
+    value: 55,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-02T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-02T07:00:00.000Z',
+    value: 72,
+    name: 'Other',
+  },
+  {
+    date: '2017-08-01T07:00:00.000Z',
+    value: 455,
+    name: 'Shining',
+  },
+  {
+    date: '2017-08-01T07:00:00.000Z',
+    value: 257,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-08-01T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-08-01T07:00:00.000Z',
+    value: 51,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-08-01T07:00:00.000Z',
+    value: 86,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-08-01T07:00:00.000Z',
+    value: 69,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-31T07:00:00.000Z',
+    value: 447,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-31T07:00:00.000Z',
+    value: 257,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-31T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-31T07:00:00.000Z',
+    value: 51,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-31T07:00:00.000Z',
+    value: 84,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-31T07:00:00.000Z',
+    value: 69,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-30T07:00:00.000Z',
+    value: 424,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-30T07:00:00.000Z',
+    value: 237,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-30T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-30T07:00:00.000Z',
+    value: 49,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-30T07:00:00.000Z',
+    value: 84,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-30T07:00:00.000Z',
+    value: 68,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-29T07:00:00.000Z',
+    value: 420,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-29T07:00:00.000Z',
+    value: 236,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-29T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-29T07:00:00.000Z',
+    value: 49,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-29T07:00:00.000Z',
+    value: 84,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-29T07:00:00.000Z',
+    value: 66,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-28T07:00:00.000Z',
+    value: 413,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-28T07:00:00.000Z',
+    value: 235,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-28T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-28T07:00:00.000Z',
+    value: 49,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-28T07:00:00.000Z',
+    value: 84,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-28T07:00:00.000Z',
+    value: 64,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-27T07:00:00.000Z',
+    value: 410,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-27T07:00:00.000Z',
+    value: 233,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-27T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-27T07:00:00.000Z',
+    value: 48,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-27T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-27T07:00:00.000Z',
+    value: 64,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-26T07:00:00.000Z',
+    value: 405,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-26T07:00:00.000Z',
+    value: 233,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-26T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-26T07:00:00.000Z',
+    value: 47,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-26T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-26T07:00:00.000Z',
+    value: 64,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-25T07:00:00.000Z',
+    value: 396,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-25T07:00:00.000Z',
+    value: 233,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-25T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-25T07:00:00.000Z',
+    value: 47,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-25T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-25T07:00:00.000Z',
+    value: 61,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-24T07:00:00.000Z',
+    value: 396,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-24T07:00:00.000Z',
+    value: 230,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-24T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-24T07:00:00.000Z',
+    value: 45,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-24T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-24T07:00:00.000Z',
+    value: 61,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-23T07:00:00.000Z',
+    value: 390,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-23T07:00:00.000Z',
+    value: 229,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-23T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-23T07:00:00.000Z',
+    value: 45,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-23T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-23T07:00:00.000Z',
+    value: 59,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-22T07:00:00.000Z',
+    value: 381,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-22T07:00:00.000Z',
+    value: 228,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-22T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-22T07:00:00.000Z',
+    value: 45,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-22T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-22T07:00:00.000Z',
+    value: 59,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-21T07:00:00.000Z',
+    value: 378,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-21T07:00:00.000Z',
+    value: 228,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-21T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-21T07:00:00.000Z',
+    value: 42,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-21T07:00:00.000Z',
+    value: 77,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-21T07:00:00.000Z',
+    value: 59,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-20T07:00:00.000Z',
+    value: 372,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-20T07:00:00.000Z',
+    value: 227,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-20T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-20T07:00:00.000Z',
+    value: 42,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-20T07:00:00.000Z',
+    value: 76,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-20T07:00:00.000Z',
+    value: 59,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-19T07:00:00.000Z',
+    value: 369,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-19T07:00:00.000Z',
+    value: 224,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-19T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-19T07:00:00.000Z',
+    value: 42,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-19T07:00:00.000Z',
+    value: 76,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-19T07:00:00.000Z',
+    value: 59,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-18T07:00:00.000Z',
+    value: 362,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-18T07:00:00.000Z',
+    value: 222,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-18T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-18T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-18T07:00:00.000Z',
+    value: 76,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-18T07:00:00.000Z',
+    value: 57,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-17T07:00:00.000Z',
+    value: 354,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-17T07:00:00.000Z',
+    value: 221,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-17T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-17T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-17T07:00:00.000Z',
+    value: 74,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-17T07:00:00.000Z',
+    value: 55,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-16T07:00:00.000Z',
+    value: 351,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-16T07:00:00.000Z',
+    value: 211,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-16T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-16T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-16T07:00:00.000Z',
+    value: 74,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-16T07:00:00.000Z',
+    value: 55,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-15T07:00:00.000Z',
+    value: 344,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-15T07:00:00.000Z',
+    value: 211,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-15T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-15T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-15T07:00:00.000Z',
+    value: 74,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-15T07:00:00.000Z',
+    value: 54,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-14T07:00:00.000Z',
+    value: 344,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-14T07:00:00.000Z',
+    value: 211,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-14T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-14T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-14T07:00:00.000Z',
+    value: 74,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-14T07:00:00.000Z',
+    value: 54,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-13T07:00:00.000Z',
+    value: 342,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-13T07:00:00.000Z',
+    value: 207,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-13T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-13T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-13T07:00:00.000Z',
+    value: 74,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-13T07:00:00.000Z',
+    value: 49,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-12T07:00:00.000Z',
+    value: 334,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-12T07:00:00.000Z',
+    value: 205,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-12T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-12T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-12T07:00:00.000Z',
+    value: 74,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-12T07:00:00.000Z',
+    value: 48,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-11T07:00:00.000Z',
+    value: 326,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-11T07:00:00.000Z',
+    value: 202,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-11T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-11T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-11T07:00:00.000Z',
+    value: 72,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-11T07:00:00.000Z',
+    value: 47,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-10T07:00:00.000Z',
+    value: 317,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-10T07:00:00.000Z',
+    value: 195,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-10T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-10T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-10T07:00:00.000Z',
+    value: 72,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-10T07:00:00.000Z',
+    value: 47,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-09T07:00:00.000Z',
+    value: 301,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-09T07:00:00.000Z',
+    value: 191,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-09T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-09T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-09T07:00:00.000Z',
+    value: 70,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-09T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-08T07:00:00.000Z',
+    value: 298,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-08T07:00:00.000Z',
+    value: 191,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-08T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-08T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-08T07:00:00.000Z',
+    value: 69,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-08T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-07T07:00:00.000Z',
+    value: 297,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-07T07:00:00.000Z',
+    value: 191,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-07T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-07T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-07T07:00:00.000Z',
+    value: 69,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-07T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-06T07:00:00.000Z',
+    value: 295,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-06T07:00:00.000Z',
+    value: 191,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-06T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-06T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-06T07:00:00.000Z',
+    value: 69,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-06T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-05T07:00:00.000Z',
+    value: 293,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-05T07:00:00.000Z',
+    value: 190,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-05T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-05T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-05T07:00:00.000Z',
+    value: 69,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-05T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-04T07:00:00.000Z',
+    value: 290,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-04T07:00:00.000Z',
+    value: 185,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-04T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-04T07:00:00.000Z',
+    value: 39,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-04T07:00:00.000Z',
+    value: 67,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-04T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-03T07:00:00.000Z',
+    value: 278,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-03T07:00:00.000Z',
+    value: 180,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-03T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-03T07:00:00.000Z',
+    value: 38,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-03T07:00:00.000Z',
+    value: 67,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-03T07:00:00.000Z',
+    value: 45,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-02T07:00:00.000Z',
+    value: 274,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-02T07:00:00.000Z',
+    value: 175,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-02T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-02T07:00:00.000Z',
+    value: 38,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-02T07:00:00.000Z',
+    value: 67,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-02T07:00:00.000Z',
+    value: 44,
+    name: 'Other',
+  },
+  {
+    date: '2017-07-01T07:00:00.000Z',
+    value: 272,
+    name: 'Shining',
+  },
+  {
+    date: '2017-07-01T07:00:00.000Z',
+    value: 173,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-07-01T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-07-01T07:00:00.000Z',
+    value: 38,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-07-01T07:00:00.000Z',
+    value: 67,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-07-01T07:00:00.000Z',
+    value: 42,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-30T07:00:00.000Z',
+    value: 264,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-30T07:00:00.000Z',
+    value: 169,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-30T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-30T07:00:00.000Z',
+    value: 36,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-30T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-30T07:00:00.000Z',
+    value: 42,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-29T07:00:00.000Z',
+    value: 258,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-29T07:00:00.000Z',
+    value: 168,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-29T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-29T07:00:00.000Z',
+    value: 36,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-29T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-29T07:00:00.000Z',
+    value: 42,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-28T07:00:00.000Z',
+    value: 252,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-28T07:00:00.000Z',
+    value: 164,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-28T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-28T07:00:00.000Z',
+    value: 36,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-28T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-28T07:00:00.000Z',
+    value: 42,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-27T07:00:00.000Z',
+    value: 234,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-27T07:00:00.000Z',
+    value: 161,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-27T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-27T07:00:00.000Z',
+    value: 36,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-27T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-27T07:00:00.000Z',
+    value: 39,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-26T07:00:00.000Z',
+    value: 227,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-26T07:00:00.000Z',
+    value: 160,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-26T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-26T07:00:00.000Z',
+    value: 35,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-26T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-26T07:00:00.000Z',
+    value: 39,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-25T07:00:00.000Z',
+    value: 220,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-25T07:00:00.000Z',
+    value: 157,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-25T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-25T07:00:00.000Z',
+    value: 35,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-25T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-25T07:00:00.000Z',
+    value: 39,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-24T07:00:00.000Z',
+    value: 215,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-24T07:00:00.000Z',
+    value: 143,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-24T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-24T07:00:00.000Z',
+    value: 33,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-24T07:00:00.000Z',
+    value: 57,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-24T07:00:00.000Z',
+    value: 37,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-23T07:00:00.000Z',
+    value: 208,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-23T07:00:00.000Z',
+    value: 139,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-23T07:00:00.000Z',
+    value: 0,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-23T07:00:00.000Z',
+    value: 33,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-23T07:00:00.000Z',
+    value: 54,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-23T07:00:00.000Z',
+    value: 32,
+    name: 'Other',
+  },
+  {
+    date: '2017-06-22T07:00:00.000Z',
+    value: 185,
+    name: 'Shining',
+  },
+  {
+    date: '2017-06-22T07:00:00.000Z',
+    value: 123,
+    name: 'Flashing',
+  },
+  {
+    date: '2017-06-22T07:00:00.000Z',
+    value: 1,
+    name: 'Glittering',
+  },
+  {
+    date: '2017-06-22T07:00:00.000Z',
+    value: 32,
+    name: 'Blazing',
+  },
+  {
+    date: '2017-06-22T07:00:00.000Z',
+    value: 51,
+    name: 'Sunny',
+  },
+  {
+    date: '2017-06-22T07:00:00.000Z',
+    value: 23,
+    name: 'Other',
+  },
+];

--- a/packages/integration/consumers/typescript/src/data/stacked-bar-sample.ts
+++ b/packages/integration/consumers/typescript/src/data/stacked-bar-sample.ts
@@ -1,0 +1,64 @@
+import { StackedBarChartDataShape } from '@britecharts/core';
+
+export const SAMPLE_STACKED_BAR_DATA: StackedBarChartDataShape[] = [
+  {
+      "name": "Shiny",
+      "value": 3,
+      "stack": "2011-01-05",
+  },
+  {
+      "name": "Shiny",
+      "value": 10,
+      "stack": "2011-01-06",
+  },
+  {
+      "name": "Shiny",
+      "value": 16,
+      "stack": "2011-01-07",
+  },
+  {
+      "name": "Shiny",
+      "value": 23,
+      "stack": "2011-01-08",
+  },
+  {
+      "name": "Radiant",
+      "value": 23,
+      "stack": "2011-01-05",
+  },
+  {
+      "name": "Radiant",
+      "value": 16,
+      "stack": "2011-01-06",
+  },
+  {
+      "name": "Radiant",
+      "value": 10,
+      "stack": "2011-01-07",
+  },
+  {
+      "name": "Radiant",
+      "value": 4,
+      "stack": "2011-01-08",
+  },
+  {
+      "name": "Luminous",
+      "value": 10,
+      "stack": "2011-01-05",
+  },
+  {
+      "name": "Luminous",
+      "value": 20,
+      "stack": "2011-01-06",
+  },
+  {
+      "name": "Luminous",
+      "value": 26,
+      "stack": "2011-01-07",
+  },
+  {
+      "name": "Luminous",
+      "value": 33,
+      "stack": "2011-01-08",
+  },
+];

--- a/packages/integration/consumers/typescript/src/react/components.tsx
+++ b/packages/integration/consumers/typescript/src/react/components.tsx
@@ -1,0 +1,87 @@
+// Every @britecharts/react component built with its required props, plus its
+// props type imported by name. Compiled, never rendered.
+import {
+    Bar,
+    Bullet,
+    Donut,
+    GroupedBar,
+    Legend,
+    Line,
+    Sparkline,
+    StackedArea,
+    StackedBar,
+    Tooltip,
+} from '@britecharts/react';
+import type {
+    BarChartProps,
+    BulletChartProps,
+    DonutChartProps,
+    GroupedBarProps,
+    LegendProps,
+    LineProps,
+    SparklineProps,
+    StackedAreaProps,
+    StackedBarProps,
+    TooltipProps,
+} from '@britecharts/react';
+
+export const barProps: BarChartProps = {
+    data: [{ name: 'Luminous', value: 2 }],
+    isHorizontal: true,
+    width: 400,
+};
+export const bar = <Bar {...barProps} />;
+
+export const bulletProps: BulletChartProps = {
+    data: [{ ranges: [130, 160, 250], measures: [150], markers: [220] }],
+};
+export const bullet = <Bullet {...bulletProps} />;
+
+export const donutProps: DonutChartProps = {
+    data: [{ quantity: 1, name: 'Shiny' }],
+};
+export const donut = <Donut {...donutProps} />;
+
+export const groupedBarProps: GroupedBarProps = {
+    data: [{ name: 'Jan', group: 'A', value: 1 }],
+};
+export const groupedBar = <GroupedBar {...groupedBarProps} />;
+
+export const legendProps: LegendProps = {
+    data: [{ id: 1, quantity: 2, name: 'Shiny' }],
+};
+export const legend = <Legend {...legendProps} />;
+
+export const lineProps: LineProps = {
+    data: {
+        data: [{ topicName: 'Sales', name: 1, date: '2020-01-01', value: 1 }],
+    },
+};
+export const line = <Line {...lineProps} />;
+
+export const sparklineProps: SparklineProps = {
+    data: [{ value: 1, date: '2020-01-01' }],
+};
+export const sparkline = <Sparkline {...sparklineProps} />;
+
+export const stackedAreaProps: StackedAreaProps = {
+    data: [{ date: '2020-01-01', name: 'Direct', value: 1 }],
+};
+export const stackedArea = <StackedArea {...stackedAreaProps} />;
+
+export const stackedBarProps: StackedBarProps = {
+    data: [{ name: 'Jan', stack: 'A', value: 1 }],
+};
+export const stackedBar = <StackedBar {...stackedBarProps} />;
+
+export const tooltipProps: TooltipProps = {
+    data: [],
+    xAxisValueType: 'date',
+};
+export const tooltip = <Tooltip {...tooltipProps} />;
+
+// The props are typed, not `any`.
+// @ts-expect-error width takes a number
+export const wrongWidth = <Bar data={[]} width="wide" />;
+// @ts-expect-error data is required
+export const missingData = <Donut />;

--- a/packages/integration/consumers/typescript/tsconfig.base.json
+++ b/packages/integration/consumers/typescript/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": false,
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/integration/consumers/typescript/tsconfig.bundler.json
+++ b/packages/integration/consumers/typescript/tsconfig.bundler.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
+}

--- a/packages/integration/consumers/typescript/tsconfig.node.json
+++ b/packages/integration/consumers/typescript/tsconfig.node.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "moduleResolution": "node"
+  }
+}

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -10,11 +10,14 @@
     "start": "BRITECHARTS_SOURCE=1 vite --config consumers/vanilla/vite.config.js --open",
     "test:tarballs": "node --test tests/tarball.test.js",
     "test:require": "node --test tests/require.test.js",
+    "test:types": "node --test tests/types.test.js",
     "test:browser": "playwright test",
-    "test:integration": "yarn run pack && yarn run install:consumers && yarn run test:tarballs && yarn run test:require && yarn run test:browser"
+    "test:integration": "yarn run pack && yarn run install:consumers && yarn run test:tarballs && yarn run test:require && yarn run test:types && yarn run test:browser"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
     "@playwright/test": "^1.63.0",
+    "publint": "^0.3.24",
     "rimraf": "^2.6.3",
     "vite": "^8.2.2"
   }

--- a/packages/integration/tests/tarball.test.js
+++ b/packages/integration/tests/tarball.test.js
@@ -5,11 +5,31 @@
 // one, or a build config silently dropping an output directory, does.
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { execFileSync } = require('node:child_process');
+const { execFileSync, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const TARBALLS = path.resolve(__dirname, '..', '.tarballs');
+
+// publint and attw findings we accept, each with the reason. Everything else
+// they report fails the test.
+//
+// The three below share one root cause: the packages have no "type" field,
+// so Node reads src/*.js as CommonJS even though the files are ES modules.
+// Bundlers (the `import` condition's real audience), CommonJS consumers and
+// TypeScript's node10/bundler resolutions are all unaffected, and Node 20.19+
+// detects the syntax at runtime. Node ESM (`import` from a Node script) is
+// not a supported consumer of a browser charting library; proper ESM output
+// arrives with the Vite build (H22), which retires all three waivers.
+const WAIVED_PUBLINT = new Set([
+    'FILE_INVALID_FORMAT', // src/*.js is ESM in a CommonJS package
+    'EXPORTS_TYPES_INVALID_FORMAT', // the .d.ts serving the import condition is read as CJS
+]);
+const WAIVED_ATTW = new Set([
+    'UnexpectedModuleSyntax', // same: ESM syntax in a file Node treats as CJS
+    'NamedExports', // Node ESM cannot see named exports on the webpack UMD bundle
+]);
 
 // Things that must never ship from any package.
 const COMMON_DENY = [
@@ -173,6 +193,48 @@ for (const [name, { allow, deny }] of Object.entries(PACKAGES)) {
                     `${field} points at ${manifest[field]}, which is not in the tarball`
                 );
             }
+        });
+
+        await t.test('passes publint (errors, and warnings not waived)', async () => {
+            const { publint } = await import('publint');
+            const { formatMessage } = await import('publint/utils');
+            const tarball = fs.readFileSync(path.join(TARBALLS, `${name}.tgz`));
+            const { messages, pkg } = await publint({ pack: { tarball } });
+            const failing = messages
+                .filter((m) => m.type === 'error' || (m.type === 'warning' && !WAIVED_PUBLINT.has(m.code)))
+                .map((m) => `${m.type} ${m.code}: ${formatMessage(m, pkg ?? manifest)}`);
+
+            assert.deepEqual(failing, []);
+        });
+
+        await t.test('passes attw (problems not waived)', () => {
+            if (!manifest.types) {
+                return; // nothing for attw to check
+            }
+            // attw exits non-zero when it finds problems, and a process that
+            // exits with a pipe on stdout loses everything past 64 KB. A file
+            // is written synchronously, so the report goes there.
+            const reportFile = path.join(os.tmpdir(), `attw-${name}-${process.pid}.json`);
+            const fd = fs.openSync(reportFile, 'w');
+            const result = spawnSync(
+                'yarn',
+                ['attw', path.join(TARBALLS, `${name}.tgz`), '--format', 'json'],
+                { cwd: path.resolve(__dirname, '..'), stdio: ['ignore', fd, 'pipe'], encoding: 'utf8' }
+            );
+            fs.closeSync(fd);
+            let report;
+            try {
+                report = JSON.parse(fs.readFileSync(reportFile, 'utf8'));
+            } catch {
+                assert.fail(`attw produced no JSON (exit ${result.status}):\n${result.stderr}`);
+            } finally {
+                fs.rmSync(reportFile, { force: true });
+            }
+            const problems = Object.entries(report.problems ?? {})
+                .filter(([kind]) => !WAIVED_ATTW.has(kind))
+                .map(([kind, list]) => `${kind}: ${JSON.stringify(list)}`);
+
+            assert.deepEqual(problems, []);
         });
 
         await t.test('is publishable', () => {

--- a/packages/integration/tests/types.test.js
+++ b/packages/integration/tests/types.test.js
@@ -1,0 +1,37 @@
+// Tier 2b: the published typings compile for a TypeScript consumer, under the
+// two module resolutions users actually have. skipLibCheck is off in the
+// consumer, so the library's own .d.ts files are checked, not only their use.
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CONSUMER = path.resolve(__dirname, '..', 'consumers', 'typescript');
+const TSC = path.join(CONSUMER, 'node_modules', 'typescript', 'bin', 'tsc');
+
+const RESOLUTIONS = [
+    ['node', 'moduleResolution: node (Jest, older setups; ignores exports)'],
+    ['bundler', 'moduleResolution: bundler (Vite, TS 5; honours exports)'],
+];
+
+for (const [name, how] of RESOLUTIONS) {
+    test(`T · typings compile under ${how}`, () => {
+        assert.ok(
+            fs.existsSync(TSC),
+            'consumers/typescript is not installed; run `yarn install:consumers` first'
+        );
+
+        const result = spawnSync(
+            process.execPath,
+            [TSC, '-p', `tsconfig.${name}.json`, '--pretty', 'false'],
+            { cwd: CONSUMER, encoding: 'utf8' }
+        );
+
+        assert.equal(
+            result.status,
+            0,
+            `tsc -p tsconfig.${name}.json failed:\n${result.stdout}${result.stderr}`
+        );
+    });
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -81,5 +81,16 @@
     "!**/*.stories.mdx",
     "!**/*DataBuilder.js",
     "!**/*.fixtures.js"
-  ]
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/typings/index.d.ts",
+      "import": "./dist/umd/bundle/react.bundled.min.js",
+      "require": "./dist/umd/bundle/react.bundled.min.js",
+      "default": "./dist/umd/bundle/react.bundled.min.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  }
 }

--- a/packages/react/src/typings/charts/Bar.d.ts
+++ b/packages/react/src/typings/charts/Bar.d.ts
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { LocalObject } from 'britecharts/src/typings/common/local';
+import { LocalObject } from '@britecharts/core';
 
 export interface BarChartProps {
     /**

--- a/packages/react/src/typings/charts/GroupedBar.d.ts
+++ b/packages/react/src/typings/charts/GroupedBar.d.ts
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { LocalObject } from 'britecharts/src/typings/common/local';
+import { LocalObject } from '@britecharts/core';
 
 export interface GroupedBarProps {
     /**

--- a/packages/react/src/typings/charts/StackedBar.d.ts
+++ b/packages/react/src/typings/charts/StackedBar.d.ts
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { LocalObject } from 'britecharts/src/typings/common/local';
+import { LocalObject } from '@britecharts/core';
 
 export interface StackedBarProps {
     /**

--- a/packages/react/src/typings/charts/Tooltip.d.ts
+++ b/packages/react/src/typings/charts/Tooltip.d.ts
@@ -94,7 +94,7 @@ export interface TooltipProps {
      * Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'.
      * When set to number, the x-Axis values won't be parsed as dates anymore, but as numbers.
      */
-    xAxisValueType: 'date' | 'nunber';
+    xAxisValueType: 'date' | 'number';
 
     /**
      * Internally used, do not overwrite.

--- a/packages/wrappers/package.json
+++ b/packages/wrappers/package.json
@@ -57,5 +57,15 @@
     "!**/*.stories.mdx",
     "!**/*DataBuilder.js",
     "!**/*.fixtures.js"
-  ]
+  ],
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "require": "./dist/umd/bundle/wrappers.bundled.min.js",
+      "default": "./dist/umd/bundle/wrappers.bundled.min.js"
+    },
+    "./dist/*": "./dist/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,12 +320,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@andrewbranch/untar.js@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "@andrewbranch/untar.js@npm:1.0.4"
+  checksum: 68781b11bd879fe50835450ff4b5469cb04a98a3291fa4bb0af1024a5271e7f0fac759a55f46e7c90c0b79b0a0e0b9e8753b26cf37b90f6b949f922db5d7074f
+  languageName: node
+  linkType: hard
+
 "@arcanis/slice-ansi@npm:^1.0.2":
   version: 1.1.1
   resolution: "@arcanis/slice-ansi@npm:1.1.1"
   dependencies:
     grapheme-splitter: ^1.0.4
   checksum: 14ed60cb45750d386c64229ac7bab20e10eedc193503fa4decff764162d329d6d3363ed2cd3debec833186ee54affe4f824f6e8eff531295117fd1ebda200270
+  languageName: node
+  linkType: hard
+
+"@arethetypeswrong/cli@npm:^0.18.5":
+  version: 0.18.5
+  resolution: "@arethetypeswrong/cli@npm:0.18.5"
+  dependencies:
+    "@arethetypeswrong/core": 0.18.5
+    chalk: ^4.1.2
+    cli-table3: ^0.6.3
+    commander: ^10.0.1
+    marked: ^9.1.2
+    marked-terminal: ^7.1.0
+    semver: ^7.5.4
+  bin:
+    attw: ./dist/index.js
+  checksum: 1eb24485f06c6847f531029615820e3e5e843a70a2e3a7da8cf7215f6c982571c9e40401c4381e765a5127e7c34d6f3b9394e954c1452ce6e8f9634bdd21021e
+  languageName: node
+  linkType: hard
+
+"@arethetypeswrong/core@npm:0.18.5":
+  version: 0.18.5
+  resolution: "@arethetypeswrong/core@npm:0.18.5"
+  dependencies:
+    "@andrewbranch/untar.js": ^1.0.3
+    "@loaderkit/resolve": ^1.0.2
+    cjs-module-lexer: ^1.2.3
+    fflate: ^0.8.3
+    lru-cache: ^11.0.1
+    semver: ^7.5.4
+    typescript: 5.6.1-rc
+    validate-npm-package-name: ^5.0.0
+  checksum: 70ad2ce13fb79acd14bcca261103bf86863b620d5e5fdb8d98399e67b2875d606a4169ac6d797825b03675af19181d6723ef24e980790ecac0394f083ee890f7
   languageName: node
   linkType: hard
 
@@ -3330,6 +3370,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braidai/lang@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "@braidai/lang@npm:1.1.2"
+  checksum: b15b960f5d29f5bdec39c77bfdfbe4c165fbb676998fc78c4543b2bf855b5d02260a10a4069c02db348c112e8177f3bc69d3baec7c4776822015b525c0fddf76
+  languageName: node
+  linkType: hard
+
 "@britecharts/core@workspace:^, @britecharts/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@britecharts/core@workspace:packages/core"
@@ -3341,7 +3388,7 @@ __metadata:
     "@storybook/html-webpack5": 8.6.14
     "@storybook/manager-api": 8.6.14
     "@storybook/theming": 8.6.14
-    "@types/d3-selection": ^1.4.1
+    "@types/d3-selection": ^3.0.0
     "@typescript-eslint/parser": ^4.6.1
     babel-loader: ^8.2.3
     babel-plugin-istanbul: ^6.0.0
@@ -3438,7 +3485,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@britecharts/integration@workspace:packages/integration"
   dependencies:
+    "@arethetypeswrong/cli": ^0.18.5
     "@playwright/test": ^1.63.0
+    publint: ^0.3.24
     rimraf: ^2.6.3
     vite: ^8.2.2
   languageName: unknown
@@ -5156,6 +5205,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@loaderkit/resolve@npm:^1.0.2":
+  version: 1.0.6
+  resolution: "@loaderkit/resolve@npm:1.0.6"
+  dependencies:
+    "@braidai/lang": ^1.0.0
+  checksum: 7da3f4c02023e5f486ad514f06ec13c4fcde8a6cb32b27f699a97233ca62c21dd739074e544342936d2097f513a693493c077a5cd7fbc6dbe55bd5e618ab5507
+  languageName: node
+  linkType: hard
+
 "@manypkg/find-root@npm:^3.1.0":
   version: 3.1.0
   resolution: "@manypkg/find-root@npm:3.1.0"
@@ -5471,6 +5529,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@publint/pack@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "@publint/pack@npm:0.1.7"
+  dependencies:
+    tinyexec: ^1.3.0
+  checksum: a1da172ba3fc9e8ae703797fc622eac9bf4d61d4332e66ee45fcacc5eb49da41bc48119e9c81997b4b71a939391aee6b239a85ab54f3d17a7ef69bc385c86a20
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm-eabi@npm:1.2.7":
   version: 1.2.7
   resolution: "@rolldown/binding-android-arm-eabi@npm:1.2.7"
@@ -5620,7 +5687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^4.0.0":
+"@sindresorhus/is@npm:^4.0.0, @sindresorhus/is@npm:^4.6.0":
   version: 4.6.0
   resolution: "@sindresorhus/is@npm:4.6.0"
   checksum: 83839f13da2c29d55c97abc3bc2c55b250d33a0447554997a85c539e058e57b8da092da396e252b11ec24a0279a0bed1f537fa26302209327060643e327f81d2
@@ -6576,10 +6643,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-selection@npm:^1.4.1":
-  version: 1.4.3
-  resolution: "@types/d3-selection@npm:1.4.3"
-  checksum: 6ab11ac517d5878dca18021c698576f6678fb8374dcf1c519021969ba90d6c84fb8368f8f555bddce78b278b95d40f438398e1b082a96c257b7103ec543ad28b
+"@types/d3-selection@npm:^3.0.0":
+  version: 3.0.11
+  resolution: "@types/d3-selection@npm:3.0.11"
+  checksum: 4b76630f76dffdafc73cdc786d73e7b4c96f40546483074b3da0e7fe83fd7f5ed9bc6c50f79bcef83595f943dcc9ed6986953350f39371047af644cc39c41b43
   languageName: node
   linkType: hard
 
@@ -8590,6 +8657,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^7.0.0":
+  version: 7.3.0
+  resolution: "ansi-escapes@npm:7.3.0"
+  dependencies:
+    environment: ^1.0.0
+  checksum: b5e99117d07abdff097eff474dd0bf64638c70c35cbc3758baf8b77cb8921bf406a082786138e21f7e2e3498137a2d859219103db85435de6551844e6db6cb4e
+  languageName: node
+  linkType: hard
+
 "ansi-html-community@npm:0.0.8, ansi-html-community@npm:^0.0.8":
   version: 0.0.8
   resolution: "ansi-html-community@npm:0.0.8"
@@ -8643,6 +8719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.1.0":
+  version: 6.3.0
+  resolution: "ansi-regex@npm:6.3.0"
+  checksum: 85e15deee80d6e52e75864897b6f7b8a8cfc5befe1868f03e3b6bf8925b9b667cf67d4aeafc6d038398f2f11c3813e7b40ad79affdd29a9c491b3585bfa125d5
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^2.2.1":
   version: 2.2.1
   resolution: "ansi-styles@npm:2.2.1"
@@ -8682,7 +8765,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"any-promise@npm:^1.1.0, any-promise@npm:~1.3.0":
+"any-promise@npm:^1.0.0, any-promise@npm:^1.1.0, any-promise@npm:~1.3.0":
   version: 1.3.0
   resolution: "any-promise@npm:1.3.0"
   checksum: 0ee8a9bdbe882c90464d75d1f55cf027f5458650c4bd1f0467e65aec38ccccda07ca5844969ee77ed46d04e7dded3eaceb027e8d32f385688523fe305fa7e1de
@@ -10998,6 +11081,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^5.4.1":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 4ee2d47a626d79ca27cb5299ecdcce840ef5755e287412536522344db0fc51ca0f6d6433202332c29e2288c6a90a2b31f3bd626bc8c14743b6b6ee28abd3b796
+  languageName: node
+  linkType: hard
+
 "char-regex@npm:^1.0.2":
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
@@ -11286,6 +11376,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-highlight@npm:^2.1.11":
+  version: 2.1.11
+  resolution: "cli-highlight@npm:2.1.11"
+  dependencies:
+    chalk: ^4.0.0
+    highlight.js: ^10.7.1
+    mz: ^2.4.0
+    parse5: ^5.1.1
+    parse5-htmlparser2-tree-adapter: ^6.0.0
+    yargs: ^16.0.0
+  bin:
+    highlight: bin/highlight
+  checksum: 0a60e60545e39efea78c1732a25b91692017ec40fb6e9497208dc0eeeae69991d3923a8d6e4edd0543db3c395ed14529a33dd4d0353f1679c5b6dded792a8496
+  languageName: node
+  linkType: hard
+
 "cli-table3@npm:^0.6.2":
   version: 0.6.3
   resolution: "cli-table3@npm:0.6.3"
@@ -11296,6 +11402,19 @@ __metadata:
     "@colors/colors":
       optional: true
   checksum: 09897f68467973f827c04e7eaadf13b55f8aec49ecd6647cc276386ea660059322e2dd8020a8b6b84d422dbdd619597046fa89cbbbdc95b2cea149a2df7c096c
+  languageName: node
+  linkType: hard
+
+"cli-table3@npm:^0.6.3, cli-table3@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "cli-table3@npm:0.6.5"
+  dependencies:
+    "@colors/colors": 1.5.0
+    string-width: ^4.2.0
+  dependenciesMeta:
+    "@colors/colors":
+      optional: true
+  checksum: ab7afbf4f8597f1c631f3ee6bb3481d0bfeac8a3b81cffb5a578f145df5c88003b6cfff46046a7acae86596fdd03db382bfa67f20973b6b57425505abc47e42c
   languageName: node
   linkType: hard
 
@@ -11604,6 +11723,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
+"commander@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "commander@npm:10.0.1"
+  checksum: 436901d64a818295803c1996cd856621a74f30b9f9e28a588e726b2b1670665bccd7c1a77007ebf328729f0139838a88a19265858a0fa7a8728c4656796db948
   languageName: node
   linkType: hard
 
@@ -13919,6 +14045,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emojilib@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "emojilib@npm:2.4.0"
+  checksum: ea241c342abda5a86ffd3a15d8f4871a616d485f700e03daea38c6ce38205847cea9f6ff8d5e962c00516b004949cc96c6e37b05559ea71a0a496faba53b56da
+  languageName: node
+  linkType: hard
+
 "emojis-list@npm:^2.0.0":
   version: 2.1.0
   resolution: "emojis-list@npm:2.1.0"
@@ -14073,6 +14206,13 @@ __metadata:
   version: 0.0.6
   resolution: "env-variable@npm:0.0.6"
   checksum: 8c3130111cfc264644611df5deea2599e9c0915413302c501df9cc37c5eb894a32944d8799f947bcf9b1485b8bb56f025219318463fc9956b87fb4cff2c9f56f
+  languageName: node
+  linkType: hard
+
+"environment@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "environment@npm:1.1.0"
+  checksum: dd3c1b9825e7f71f1e72b03c2344799ac73f2e9ef81b78ea8b373e55db021786c6b9f3858ea43a436a2c4611052670ec0afe85bc029c384cc71165feee2f4ba6
   languageName: node
   linkType: hard
 
@@ -15435,6 +15575,13 @@ __metadata:
   dependencies:
     xml-js: ^1.6.11
   checksum: 2e6992a675a049511eef7bda8ca6c08cb9540cd10e8b275ec4c95d166228ec445a335fa8de990358759f248a92861e51decdcd32bf1c54737d5b7aed7c7ffe97
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: a2a417e8fb5128b946cb397ab59a90e089057cba492f2c17a89c4af6ba8568b3da72ed36ef1efe901df7858a20964ce56e84d282e60498be1947fcc6133bc891
   languageName: node
   linkType: hard
 
@@ -16951,6 +17098,13 @@ __metadata:
   bin:
     he: bin/he
   checksum: 3d4d6babccccd79c5c5a3f929a68af33360d6445587d628087f39a965079d84f18ce9c3d3f917ee1e3978916fc833bb8b29377c3b403f919426f91bc6965e7a7
+  languageName: node
+  linkType: hard
+
+"highlight.js@npm:^10.7.1":
+  version: 10.7.3
+  resolution: "highlight.js@npm:10.7.3"
+  checksum: defeafcd546b535d710d8efb8e650af9e3b369ef53e28c3dc7893eacfe263200bba4c5fcf43524ae66d5c0c296b1af0870523ceae3e3104d24b7abf6374a4fea
   languageName: node
   linkType: hard
 
@@ -20226,6 +20380,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.1":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: ea040bdd8255384d1965c09983e1357ef6eca044747917c2f9db610f3fc773a518ea86bbcffb3b376f793ed61729f240c69cc5593ec89062d64e31c50973f3c0
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.1.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -20447,6 +20608,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked-terminal@npm:^7.1.0":
+  version: 7.3.0
+  resolution: "marked-terminal@npm:7.3.0"
+  dependencies:
+    ansi-escapes: ^7.0.0
+    ansi-regex: ^6.1.0
+    chalk: ^5.4.1
+    cli-highlight: ^2.1.11
+    cli-table3: ^0.6.5
+    node-emoji: ^2.2.0
+    supports-hyperlinks: ^3.1.0
+  peerDependencies:
+    marked: ">=1 <16"
+  checksum: eb0d13ab5bfbec6be412157529fde83ea6c026a83a280ef449a27bc8fddb5ddd92904499cfb275efa96d696f119453d566ad58805c14167055c4f58a7891ac0f
+  languageName: node
+  linkType: hard
+
 "marked@npm:^4.0.10":
   version: 4.0.12
   resolution: "marked@npm:4.0.12"
@@ -20462,6 +20640,15 @@ __metadata:
   bin:
     marked: bin/marked.js
   checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
+  languageName: node
+  linkType: hard
+
+"marked@npm:^9.1.2":
+  version: 9.1.6
+  resolution: "marked@npm:9.1.6"
+  bin:
+    marked: bin/marked.js
+  checksum: fc8db42e993d0b97a6f12b8edd93635fa30259ef7088982c714b1c0f54b16946dda54f1bb8a80ab1bd6914647a7217a4f482eda96eb7049bf67437c79e75a609
   languageName: node
   linkType: hard
 
@@ -21159,6 +21346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mri@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "mri@npm:1.2.0"
+  checksum: 83f515abbcff60150873e424894a2f65d68037e5a7fcde8a9e2b285ee9c13ac581b63cfc1e6826c4732de3aeb84902f7c1e16b7aff46cd3f897a0f757a894e85
+  languageName: node
+  linkType: hard
+
 "mrmime@npm:^1.0.0":
   version: 1.0.0
   resolution: "mrmime@npm:1.0.0"
@@ -21222,6 +21416,17 @@ __metadata:
   version: 0.0.7
   resolution: "mute-stream@npm:0.0.7"
   checksum: a9d4772c1c84206aa37c218ed4751cd060239bf1d678893124f51e037f6f22f4a159b2918c030236c93252638a74beb29c9b1fd3267c9f24d4b3253cf1eaa86f
+  languageName: node
+  linkType: hard
+
+"mz@npm:^2.4.0":
+  version: 2.7.0
+  resolution: "mz@npm:2.7.0"
+  dependencies:
+    any-promise: ^1.0.0
+    object-assign: ^4.0.1
+    thenify-all: ^1.0.0
+  checksum: 8427de0ece99a07e9faed3c0c6778820d7543e3776f9a84d22cf0ec0a8eb65f6e9aee9c9d353ff9a105ff62d33a9463c6ca638974cc652ee8140cd1e35951c87
   languageName: node
   linkType: hard
 
@@ -21357,6 +21562,18 @@ __metadata:
   dependencies:
     lodash: ^4.17.21
   checksum: e8c856c04a1645062112a72e59a98b203505ed5111ff84a3a5f40611afa229b578c7d50f1e6a7f17aa62baeea4a640d2e2f61f63afc05423aa267af10977fb2b
+  languageName: node
+  linkType: hard
+
+"node-emoji@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "node-emoji@npm:2.2.0"
+  dependencies:
+    "@sindresorhus/is": ^4.6.0
+    char-regex: ^1.0.2
+    emojilib: ^2.4.0
+    skin-tone: ^2.0.0
+  checksum: 9642bee0b8c5f2124580e6a2d4c5ec868987bc77b6ce3a335bbec8db677082cbe1a9b72c11aac60043396a8d36e0afad4bcc33d92105d103d2d1b6a59106219a
   languageName: node
   linkType: hard
 
@@ -22301,6 +22518,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5-htmlparser2-tree-adapter@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "parse5-htmlparser2-tree-adapter@npm:6.0.1"
+  dependencies:
+    parse5: ^6.0.1
+  checksum: 1848378b355d027915645c13f13f982e60502d201f53bc2067a508bf2dba4aac08219fc781dcd160167f5f50f0c73f58d20fa4fb3d90ee46762c20234fa90a6d
+  languageName: node
+  linkType: hard
+
 "parse5-htmlparser2-tree-adapter@npm:^7.0.0":
   version: 7.0.0
   resolution: "parse5-htmlparser2-tree-adapter@npm:7.0.0"
@@ -22308,6 +22534,13 @@ __metadata:
     domhandler: ^5.0.2
     parse5: ^7.0.0
   checksum: fc5d01e07733142a1baf81de5c2a9c41426c04b7ab29dd218acb80cd34a63177c90aff4a4aee66cf9f1d0aeecff1389adb7452ad6f8af0a5888e3e9ad6ef733d
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "parse5@npm:5.1.1"
+  checksum: 613a714af4c1101d1cb9f7cece2558e35b9ae8a0c03518223a4a1e35494624d9a9ad5fad4c13eab66a0e0adccd9aa3d522fc8f5f9cc19789e0579f3fa0bdfc65
   languageName: node
   linkType: hard
 
@@ -23927,6 +24160,20 @@ __metadata:
     randombytes: ^2.0.1
     safe-buffer: ^5.1.2
   checksum: 215d446e43cef021a20b67c1df455e5eea134af0b1f9b8a35f9e850abf32991b0c307327bc5b9bc07162c288d5cdb3d4a783ea6c6640979ed7b5017e3e0c9935
+  languageName: node
+  linkType: hard
+
+"publint@npm:^0.3.24":
+  version: 0.3.24
+  resolution: "publint@npm:0.3.24"
+  dependencies:
+    "@publint/pack": ^0.1.7
+    package-manager-detector: ^1.8.0
+    picocolors: ^1.1.1
+    sade: ^1.8.1
+  bin:
+    publint: ./src/cli.js
+  checksum: 0b39166ef2680dc5fc37d38049777a6b1072e4acc1354bb904036cb85fe06c1daabb7f41e21ba123e35d06febf6e6a9d5bbf96d62e17e99da2aa26442fe58c9d
   languageName: node
   linkType: hard
 
@@ -25573,6 +25820,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sade@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "sade@npm:1.8.1"
+  dependencies:
+    mri: ^1.1.0
+  checksum: 0756e5b04c51ccdc8221ebffd1548d0ce5a783a44a0fa9017a026659b97d632913e78f7dca59f2496aa996a0be0b0c322afd87ca72ccd909406f49dbffa0f45d
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
@@ -25916,7 +26172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.6.2, semver@npm:^7.8.1":
+"semver@npm:^7.5.4, semver@npm:^7.6.2, semver@npm:^7.8.1":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -26256,6 +26512,15 @@ __metadata:
   bin:
     sitemap: dist/cli.js
   checksum: 87a6d21b0d4a33b8c611d3bb8543d02b813c0ebfce014213ef31849b5c1439005644f19ad1593ec89815f6101355f468c9a02c251d09aa03f6fddd17e23c4be4
+  languageName: node
+  linkType: hard
+
+"skin-tone@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "skin-tone@npm:2.0.0"
+  dependencies:
+    unicode-emoji-modifier-base: ^1.0.0
+  checksum: 19de157586b8019cacc55eb25d9d640f00fc02415761f3e41a4527142970fd4e7f6af0333bc90e879858766c20a976107bb386ffd4c812289c01d51f2c8d182c
   languageName: node
   linkType: hard
 
@@ -27445,6 +27710,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-hyperlinks@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "supports-hyperlinks@npm:3.2.0"
+  dependencies:
+    has-flag: ^4.0.0
+    supports-color: ^7.0.0
+  checksum: 460594ec0024f041f61105d40f1e5fc55ffcc2d94b6048faf25a616ec8fbaea71e74d909a6851c721776f24eed67c59fd3b7c47af22a487ebab85640abdb5d3f
+  languageName: node
+  linkType: hard
+
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
@@ -27786,6 +28061,24 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: b6937a38c80c7f84d9c11dd75e49d5c44f71d95e810a3250bd1f1797fc7117c57698204adf676b71497acc205d769d65c16ae8fa10afad832ae1322630aef10a
+  languageName: node
+  linkType: hard
+
+"thenify-all@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "thenify-all@npm:1.6.0"
+  dependencies:
+    thenify: ">= 3.1.0 < 4"
+  checksum: dba7cc8a23a154cdcb6acb7f51d61511c37a6b077ec5ab5da6e8b874272015937788402fd271fdfc5f187f8cb0948e38d0a42dcc89d554d731652ab458f5343e
+  languageName: node
+  linkType: hard
+
+"thenify@npm:>= 3.1.0 < 4":
+  version: 3.3.1
+  resolution: "thenify@npm:3.3.1"
+  dependencies:
+    any-promise: ^1.0.0
+  checksum: 84e1b804bfec49f3531215f17b4a6e50fd4397b5f7c1bccc427b9c656e1ecfb13ea79d899930184f78bc2f57285c54d9a50a590c8868f4f0cef5c1d9f898b05e
   languageName: node
   linkType: hard
 
@@ -28325,6 +28618,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.6.1-rc":
+  version: 5.6.1-rc
+  resolution: "typescript@npm:5.6.1-rc"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 1d649fbb31b9bbc704ecf186eb52fc121a5658c9180ea701559948d7369e03b511cc4caf78993b28b3c86dba692cc7a2856cdc1022b6a52bb6cf68e6fde0db5e
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^3.2.1, typescript@npm:^3.9.2, typescript@npm:^3.9.3":
   version: 3.9.10
   resolution: "typescript@npm:3.9.10"
@@ -28352,6 +28655,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 17b8f816050b412403e38d48eef0e893deb6be522d6dc7caf105e54a72e34daf6835c447735fd2b28b66784e72bfbf87f627abb4818a8e43d1fa8106396128dc
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@5.6.1-rc#~builtin<compat/typescript>":
+  version: 5.6.1-rc
+  resolution: "typescript@patch:typescript@npm%3A5.6.1-rc#~builtin<compat/typescript>::version=5.6.1-rc&hash=8c6c40"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 3666eb9f33b6b0e977166f829437edee757ea5e8a0a519cc15a1c9c774ca89319a63fc33efed27fe7574209edfd0d0963e297aff96f0132cccfbf4de97534e68
   languageName: node
   linkType: hard
 
@@ -28495,6 +28808,13 @@ __metadata:
   version: 2.0.0
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.0"
   checksum: 39be078afd014c14dcd957a7a46a60061bc37c4508ba146517f85f60361acf4c7539552645ece25de840e17e293baa5556268d091ca6762747fdd0c705001a45
+  languageName: node
+  linkType: hard
+
+"unicode-emoji-modifier-base@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "unicode-emoji-modifier-base@npm:1.0.0"
+  checksum: 6e1521d35fa69493207eb8b41f8edb95985d8b3faf07c01d820a1830b5e8403e20002563e2f84683e8e962a49beccae789f0879356bf92a4ec7a4dd8e2d16fdb
   languageName: node
   linkType: hard
 
@@ -29011,6 +29331,13 @@ __metadata:
     spdx-correct: ^3.0.0
     spdx-expression-parse: ^3.0.0
   checksum: 35703ac889d419cf2aceef63daeadbe4e77227c39ab6287eeb6c1b36a746b364f50ba22e88591f5d017bc54685d8137bc2d328d0a896e4d3fd22093c0f32a9ad
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "validate-npm-package-name@npm:5.0.1"
+  checksum: 0d583a1af23aeffea7748742cf22b6802458736fb8b60323ba5949763824d46f796474b0e1b9206beb716f9d75269e19dbd7795d6b038b29d561be95dd827381
   languageName: node
   linkType: hard
 
@@ -30165,7 +30492,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.3":
+"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
@@ -30221,6 +30548,21 @@ __metadata:
     y18n: ^4.0.0
     yargs-parser: ^13.1.2
   checksum: 75c13e837eb2bb25717957ba58d277e864efc0cca7f945c98bdf6477e6ec2f9be6afa9ed8a876b251a21423500c148d7b91e88dee7adea6029bdec97af1ef3e8
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^16.0.0":
+  version: 16.2.2
+  resolution: "yargs@npm:16.2.2"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.0
+    y18n: ^5.0.5
+    yargs-parser: ^20.2.2
+  checksum: 0619aaa93d2f9bb1ec788a6bcb4d3dbd453db3097108dad3f74be326250cc86c1d57db9a829d7486adfb0e8d74bff365a6de8871c59af5d0a2f809de56d2ace2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Phase 3 of the integration package (#1036 phase 1, #1037 phase 2): the published typings get a real TypeScript consumer, tier 1 gains publint and attw, and every package declares an `exports` map.

**`packages/integration/consumers/typescript/`** — a TypeScript 5 project on the three tarballs plus React 19. Compiled, never run.

- `src/charts/*.ts` and `src/data/*.ts` — the fourteen chart sandboxes and thirteen data files from the old `britecharts-typescript-test-project`, pointed at `@britecharts/core`. Two calls dropped because they left the API before v3: `aspectRatio` on line and scatter plot, `duration` on sparkline (now `animationDuration`).
- `src/charts/expect-errors.ts` — one wrong call per chart factory under `// @ts-expect-error`, so a typing that regresses to `any` fails the build.
- `src/react/components.tsx` — all ten `@britecharts/react` components built with their required props, every `*Props` type imported by name, two expect-errors.
- `tsconfig.node.json` / `tsconfig.bundler.json` — same strict base (`skipLibCheck: false`, so the library's own `.d.ts` files are checked), differing only in `moduleResolution`.
- It deliberately does **not** install `@types/d3-selection`: core's public typings import from `d3-selection`, so core has to bring the types.

**New tier · `tests/types.test.js`** — spawns the consumer's own `tsc -p` twice and fails with the full diagnostic list.

**Tier 1 additions** in `tests/tarball.test.js` — [publint](https://publint.dev) through its API on the tarball bytes, and [attw](https://arethetypeswrong.github.io) through its CLI. attw exits non-zero when it finds problems and a process that exits with a pipe on stdout loses everything past 64 KB, so its JSON is written to a file. Four findings are waived, with the reason in the test file; all four share one cause: the packages have no `"type"` field, so Node reads the ES module sources as CommonJS. Bundlers, CommonJS consumers and TypeScript's node10/bundler resolutions are unaffected. **Node ESM is declared not a supported consumer** of a browser charting library; real ESM output arrives with the Vite build (H22) and retires the waivers.

**`exports` maps** (decision 3 from the plan) on core, wrappers and react:

- core and wrappers: `types` → the typings, `import` → `src/index.js` (bundlers, tree-shakeable), `require` and `default` → the UMD bundle.
- react: every condition → the UMD bundle, because `src/` contains JSX that no consumer's bundler transforms inside `node_modules`. (The `module` field already pointed there and would have broken any Vite user; phase 4 verifies this in a browser.)
- all three: `./dist/*`, `./src/*` and `./package.json`, so the deep paths the other consumers use keep working.

Nothing inside the repo deep-imports `@britecharts/*`, webpack 4 ignores `exports`, and the React Storybook (webpack 5, which honours it) was rebuilt to confirm.

## Motivation and Context

The old TypeScript test project was pinned to a 2020 alpha and had never been compiled against the v3 typings. Doing so found seven problems, all fixed here with one changeset (patch on all three packages):

1. **`@britecharts/react`'s typings never resolved.** `Bar`, `GroupedBar` and `StackedBar` imported `LocalObject` from `britecharts/src/typings/common/local` — the unscoped v2 package name. `LocalObject` is now exported from core's typings index and imported from `@britecharts/core`.
2. **`@types/d3-selection` was a devDependency, at v1.** The public typings import from `d3-selection`, so it moves to `dependencies` at `^3`.
3. **`highlightBarFunction(fn: (bar) => void | null)`** typed the callback's *return* as `void | null`; the `null` belonged to the callback. Any function returning the selection was rejected.
4. **`legend().clearHighlight()`** had no return type, an error for consumers with `noImplicitAny` and `skipLibCheck` off.
5. **`on()` handlers were `(...args: unknown[]) => void`**, which rejected every typed handler such as `tooltip.update` or `miniTooltip.show`. Now `any[]`, matching the untyped payloads.
6. **`TooltipProps.xAxisValueType`** accepted `'nunber'`.
7. (attw, before the `exports` map) `import { bar } from '@britecharts/core'` under node16-ESM resolved to the UMD bundle, whose named exports Node cannot see.

Relates to audit items W2 (typings), M10 (API surface: the `exports` map now defines the supported paths) and C5/G2. Plan: `managing-docs/integration-test-package-plan.md` §10.

## How Has This Been Tested?

Node 24, macOS, no environment flags.

- `yarn test:integration`: tarball **21/21** (with publint and attw), require **3/3**, types **2/2** (both resolutions), browser **6/6**. Before the fixes the types tier reported 26 errors across the two resolutions, all listed in the changeset.
- `yarn test:ci`: 43 suites, 937 passing, 14 skipped, unchanged.
- `yarn lint:js`: 0 errors, 4 pre-existing warnings.
- `yarn workspace @britecharts/react demo:build` (webpack 5) builds against the new `exports` maps.

## Screenshots (if appropriate):

N/A

## Types of changes

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] Latest master code has been merged into this branch
-   [x] No commented out code (if required, place // TODO above with explanation)
-   [x] No linting issues
-   [x] Build is successful
-   [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [x] Updated the documentation
-   [x] Added tests to cover changes
-   [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wnD3atYJGPoq5JsmEDNbm
