### PR TITLE
chore: integrations phase 5

### DIFF
--- a/.changeset/react-bundle-externalises-react.md
+++ b/.changeset/react-bundle-externalises-react.md
@@ -8,8 +8,9 @@ Two fixes found by the new React 19 consumer in the integration tests.
   carried its own copy of React 16 because that build never applied the
   externals the per-component builds use. Under React 17+ the bundled React's
   elements are rejected at render time (React 19 error 525) and nothing
-  draws. `react`, `react-dom` and `prop-types` are now externals there too,
-  which also takes 400 KB of React out of the bundle.
+  draws. `react`, `react-dom` and `prop-types` are now externals there too
+  (the bundled copy was React itself, not react-dom, so the bundle only
+  shrinks by about 8 KB; the point is correctness, not size).
 - The per-component builds (`dist/umd/charts/*.js`, `dist/cjs/charts/*.js`)
   exported `{ default: Component }` where core's per-chart builds export the
   module directly. Bundlers that follow Node's CommonJS interop (Vite 8 among

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -28,5 +28,8 @@ Review findings are written to `plan/`, which is gitignored.
   `master` line, so diffs must name `main` explicitly.
 - There is no type-check step in this repo; the `.d.ts` typings are hand-written
   and unchecked, which is why several of these files call out typings drift.
-- Never run the root `yarn test` in tooling — its `posttest` hook runs
-  `yarn format` across every `.js` file. Use `yarn test:ci`.
+- Use `yarn test:ci`, not the root `yarn test`, in tooling. (`test` carries a
+  `posttest` format hook; Yarn Berry does not run such hooks today, but keep to
+  the script that never will.)
+- `yarn test:integration` needs `yarn build:packages` first and Chromium
+  installed once (`yarn workspace @britecharts/integration playwright install chromium`).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -59,6 +59,17 @@ To generate the demos you need to:
 
 This process generates the demos and opens their Storybook interface in a new browser tab. There you can navigate the Demo of each chart and see some examples. We recommend you to use these demos as your testing platform when modifying the charts.
 
+### Running the Integration Tests
+The unit tests check the charts; the integration package checks what ships. It packs the three publishable packages the way the release does, installs them into small consumer projects (plain JavaScript, TypeScript and React) with npm, and then checks the tarball contents, `require()` paths, the typings and, with Playwright, that every way of loading a chart renders in a browser:
+
+```
+yarn build:packages
+yarn workspace @britecharts/integration playwright install chromium   # once
+yarn test:integration
+```
+
+It runs on every pull request as the **Integration** check. See [its README](../packages/integration/README.md) for the tiers and for how to add a consumption path, and `yarn workspace @britecharts/integration start` for a dev server over the consumer pages that uses the workspace source.
+
 ### Running the Documentation
 To generate the documentation you need to:
 

--- a/.github/MAINTAINING.md
+++ b/.github/MAINTAINING.md
@@ -5,6 +5,16 @@ As maintainers of the project, this is our guide. Most of the steps and guidelin
 
 Beyond this, this document provides some details that would be too low-level for contributors.
 
+## Releasing
+
+Versioning is owned by [Changesets](../.changeset): every change to a publishable package lands with a changeset file, and the **Release** workflow keeps a "Version Packages" pull request open on `main`. Merging that pull request is the release; the same workflow then publishes through `yarn npm publish`.
+
+Three things to know:
+
+- **Integration is a required check on `main`.** It packs the packages with Yarn's packer, installs them into consumer projects and tests them, so the "Version Packages" pull request cannot merge with a broken tarball, a broken `require()` path, broken typings or a chart that does not render. Keep it required.
+- **Yarn's packer is the authoritative one.** `yarn npm publish` is what ships, and it does not read the `files` field the way `npm pack` does (see the `exports`/`files` comments in each package.json). Never verify publish contents with `npm pack`.
+- **After a publish, check what actually shipped.** The **Smoke test the published packages** workflow runs on its own after every successful Release run and installs the consumers from the npm registry, with the CDN page loading from jsDelivr. It can also be started by hand from the Actions tab for any version or dist-tag. A red run there means users are affected now.
+
 ## Issue triage
 
 The triage and issue managing process will look like this:

--- a/.github/workflows/smoke-published.yml
+++ b/.github/workflows/smoke-published.yml
@@ -1,0 +1,104 @@
+name: Smoke test the published packages
+
+# The Integration workflow tests what *would* ship, from local tarballs. This
+# one tests what *did* ship: the consumers are installed from the npm registry
+# and the CDN page loads from jsDelivr. It is the only workflow whose
+# assertions touch the network, so it is never part of the PR job.
+#
+# Runs after every successful Release run (which publishes when the
+# "Version Packages" PR is merged; when Release only updated that PR the
+# version on main is usually already published and gets re-tested, or is not
+# published yet and the job says so and stops). Also runs on demand for any
+# version or dist-tag.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version or dist-tag of @britecharts/* to test (e.g. 3.0.0-beta.1, latest)'
+        required: true
+        default: latest
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+
+concurrency:
+  group: smoke-published
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke test
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v7
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Resolve the version to test
+        id: version
+        env:
+          REQUESTED: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
+        run: |
+          requested="${REQUESTED:-$(node -p "require('./packages/core/package.json').version")}"
+          resolved="$(npm view "@britecharts/core@${requested}" version --json 2>/dev/null | node -e '
+            let s = ""; process.stdin.on("data", (d) => (s += d)).on("end", () => {
+              try { const v = JSON.parse(s); console.log(Array.isArray(v) ? v.at(-1) : v); } catch { console.log(""); }
+            });')"
+          if [ -z "$resolved" ]; then
+            echo "::notice::@britecharts/core@${requested} is not on the registry; nothing to smoke test."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Testing @britecharts/*@${resolved}"
+            echo "version=${resolved}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read the Playwright version
+        if: steps.version.outputs.skip != 'true'
+        id: playwright
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        if: steps.version.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Chromium
+        if: steps.version.outputs.skip != 'true'
+        run: yarn workspace @britecharts/integration playwright install --with-deps chromium
+
+      # No pack step: the consumers install @britecharts/*@<version> from npm.
+      # The tarball tier is skipped for the same reason; the require, types
+      # and browser tiers run unchanged, plus the jsDelivr page.
+      - name: Test the published packages 🌐
+        if: steps.version.outputs.skip != 'true'
+        env:
+          BRITECHARTS_SOURCE: registry
+          BRITECHARTS_VERSION: ${{ steps.version.outputs.version }}
+          VITE_BRITECHARTS_VERSION: ${{ steps.version.outputs.version }}
+          SMOKE_REGISTRY: '1'
+        run: yarn workspace @britecharts/integration test:published
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-published
+          path: packages/integration/test-results
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <span> · </span>
   <a href="https://britecharts.github.io/britecharts/">Docs</a>
   <span> · </span>
-  <a href="https://github.com/britecharts/britecharts-test-project">Test Project</a>
+  <a href="https://github.com/britecharts/britecharts/tree/main/packages/integration/consumers">Test Projects</a>
   <span> · </span>
   <a href="https://britecharts.github.io/britecharts/docs/tutorials/tutorials-index">Storybook</a>
   <span> · </span>

--- a/packages/docs/docs/Britecharts.md
+++ b/packages/docs/docs/Britecharts.md
@@ -21,7 +21,7 @@
   <span> · </span>
   <a href="https://britecharts.github.io/britecharts/">Docs</a>
   <span> · </span>
-  <a href="https://github.com/britecharts/britecharts-test-project">Test Project</a>
+  <a href="https://github.com/britecharts/britecharts/tree/main/packages/integration/consumers">Test Projects</a>
   <span> · </span>
   <a href="https://britecharts.github.io/britecharts/docs/tutorials/tutorials-index">Storybook</a>
   <span> · </span>

--- a/packages/docs/docs/how-tos/migration-guide-2-to-3.md
+++ b/packages/docs/docs/how-tos/migration-guide-2-to-3.md
@@ -39,7 +39,7 @@ const { bar } = require('@britecharts/core');
 const bar = require('@britecharts/core/dist/umd/bar.min');
 
 ```
-You can also check more ways of loading (CommonJS and CDN) in our [Britecharts Test Project](https://github.com/britecharts/britecharts-test-project#usage)
+You can also check more ways of loading (CommonJS, UMD and CDN) in the [vanilla consumer](https://github.com/britecharts/britecharts/tree/main/packages/integration/consumers/vanilla) of our integration tests, which CI runs against every change
 
 2. Change how you show loading states
 

--- a/packages/integration/README.md
+++ b/packages/integration/README.md
@@ -55,6 +55,22 @@ Playwright (`*.spec.js`).
 [publint]: https://publint.dev
 [attw]: https://arethetypeswrong.github.io
 
+## After a release: the published packages
+
+`yarn test:published` runs the same require, types and browser tiers, but
+with the consumers installed from the npm registry instead of the tarballs,
+plus a page that loads the CDN bundle from jsDelivr:
+
+```sh
+BRITECHARTS_SOURCE=registry BRITECHARTS_VERSION=3.0.0-beta.1 \
+VITE_BRITECHARTS_VERSION=3.0.0-beta.1 SMOKE_REGISTRY=1 \
+yarn workspace @britecharts/integration test:published
+```
+
+The **Smoke test the published packages** workflow does this on its own after
+every successful Release run, and can be started from the Actions tab for any
+version or dist-tag. It is the only test that touches the network.
+
 ## Local loop for chart work
 
 ```sh

--- a/packages/integration/consumers/vanilla/README.md
+++ b/packages/integration/consumers/vanilla/README.md
@@ -12,6 +12,7 @@ from npm. One HTML page per consumption path:
 | `umd-chart.html` | `dist/umd/charts/bar.min.js` through Vite |
 | `esm-bundle.html` | `import { bar } from '@britecharts/core'` (the package `module` entry) |
 | `esm-chart.html` | `import bar from '@britecharts/core/src/charts/bar/bar.js'` |
+| `cdn-jsdelivr.html` | the published bundle from jsDelivr; only run by `smoke-published.yml` against a released version |
 
 Stylesheets are covered across the pages: the CSS bundle via a `<link>` and via
 a JS import, and the per-chart `common` + `bar` files both ways too.

--- a/packages/integration/consumers/vanilla/cdn-jsdelivr.html
+++ b/packages/integration/consumers/vanilla/cdn-jsdelivr.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CDN · published bundle from jsDelivr</title>
+    <link rel="stylesheet" href="/src/page.css">
+    <!-- Only meaningful for a published version: smoke-published.yml sets
+         VITE_BRITECHARTS_VERSION, and tests/browser.spec.js skips this page
+         otherwise. Nothing else in the suite touches the network. -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@britecharts/core@%VITE_BRITECHARTS_VERSION%/dist/styles/bundle/britecharts.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/d3-selection@3/dist/d3-selection.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@britecharts/core@%VITE_BRITECHARTS_VERSION%/dist/cdn/bundle/core.cdn.min.js"></script>
+</head>
+<body>
+    <h1>CDN · published bundle from jsDelivr</h1>
+    <div class="bar-container"></div>
+    <script>
+        var barData = [
+            { name: "Luminous", value: 2 },
+            { name: "Glittering", value: 5 },
+            { name: "Intense", value: 4 },
+            { name: "Radiant", value: 3 },
+        ];
+        var barChart = core.bar()
+            .margin({ left: 100 })
+            .isHorizontal(true)
+            .height(400)
+            .width(600);
+
+        d3.select(".bar-container").datum(barData).call(barChart);
+    </script>
+</body>
+</html>

--- a/packages/integration/consumers/vanilla/vite.config.js
+++ b/packages/integration/consumers/vanilla/vite.config.js
@@ -15,6 +15,7 @@ const pages = [
     'umd-chart',
     'esm-bundle',
     'esm-chart',
+    'cdn-jsdelivr', // published version only; see the page
 ];
 
 // BRITECHARTS_SOURCE=1 (the `start` script) points the bare specifiers at

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -13,7 +13,8 @@
     "test:require": "node --test tests/require.test.js",
     "test:types": "node --test tests/types.test.js",
     "test:browser": "playwright test",
-    "test:integration": "yarn run pack && yarn run install:consumers && yarn run test:tarballs && yarn run test:require && yarn run test:types && yarn run test:browser"
+    "test:integration": "yarn run pack && yarn run install:consumers && yarn run test:tarballs && yarn run test:require && yarn run test:types && yarn run test:browser",
+    "test:published": "yarn run install:consumers && yarn run test:require && yarn run test:types && yarn run test:browser"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",

--- a/packages/integration/scripts/install-consumers.js
+++ b/packages/integration/scripts/install-consumers.js
@@ -1,14 +1,24 @@
 /* eslint-disable no-console */
-// Installs every consumers/<name>/ project from the tarballs in .tarballs/
-// with npm, the way a user would, so dependency declarations are tested as
-// well as file contents. Then copies the files the script-tag pages need
-// into public/vendor/ so they can be served without touching the network.
+// Installs every consumers/<name>/ project with npm, the way a user would, so
+// dependency declarations are tested as well as file contents. Then copies
+// the files the script-tag pages need into public/vendor/ so they can be
+// served without touching the network.
+//
+// Two sources for the @britecharts/* packages:
+//   - tarballs (default): the `file:../../.tarballs/*.tgz` references in each
+//     consumer's package.json, produced by scripts/pack.js. What every PR runs.
+//   - registry: BRITECHARTS_SOURCE=registry BRITECHARTS_VERSION=<version>
+//     rewrites those references to the version on npm for the duration of the
+//     install. What smoke-published.yml runs after a release.
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
 const CONSUMERS_DIR = path.resolve(__dirname, '..', 'consumers');
 const TARBALLS = path.resolve(__dirname, '..', '.tarballs');
+
+const SOURCE = process.env.BRITECHARTS_SOURCE === 'registry' ? 'registry' : 'tarballs';
+const VERSION = process.env.BRITECHARTS_VERSION;
 
 // source (inside the consumer's node_modules) -> destination (inside public/)
 const VENDOR = [
@@ -17,7 +27,11 @@ const VENDOR = [
     ['d3-selection/dist/d3-selection.min.js', 'vendor/d3-selection.min.js'],
 ];
 
-if (!fs.existsSync(TARBALLS)) {
+if (SOURCE === 'registry' && !VERSION) {
+    console.error('BRITECHARTS_SOURCE=registry needs BRITECHARTS_VERSION (a version or dist-tag).');
+    process.exit(1);
+}
+if (SOURCE === 'tarballs' && !fs.existsSync(TARBALLS)) {
     console.error('.tarballs/ is missing; run `yarn pack` (scripts/pack.js) first.');
     process.exit(1);
 }
@@ -28,27 +42,45 @@ const consumers = fs
 
 for (const name of consumers) {
     const cwd = path.join(CONSUMERS_DIR, name);
+    const manifestPath = path.join(cwd, 'package.json');
+    const original = fs.readFileSync(manifestPath, 'utf8');
 
     // A fresh install every time: npm's hidden lockfile would otherwise keep
     // a previously extracted tarball when only its contents changed.
     fs.rmSync(path.join(cwd, 'node_modules'), { recursive: true, force: true });
     fs.rmSync(path.join(cwd, 'public', 'vendor'), { recursive: true, force: true });
 
-    console.log(`installing consumers/${name}`);
-    execFileSync(
-        'npm',
-        ['install', '--no-package-lock', '--no-audit', '--no-fund', '--loglevel=error'],
-        {
-            cwd,
-            stdio: 'inherit',
-            env: {
-                ...process.env,
-                // The repo root pins packageManager to Yarn; Corepack would
-                // otherwise refuse to let npm run underneath it.
-                COREPACK_ENABLE_STRICT: '0',
-            },
+    if (SOURCE === 'registry') {
+        const manifest = JSON.parse(original);
+
+        for (const dependency of Object.keys(manifest.dependencies ?? {})) {
+            if (dependency.startsWith('@britecharts/')) {
+                manifest.dependencies[dependency] = VERSION;
+            }
         }
-    );
+        fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    }
+
+    console.log(`installing consumers/${name} from ${SOURCE}${SOURCE === 'registry' ? ` (@britecharts/*@${VERSION})` : ''}`);
+    try {
+        execFileSync(
+            'npm',
+            ['install', '--no-package-lock', '--no-audit', '--no-fund', '--loglevel=error'],
+            {
+                cwd,
+                stdio: 'inherit',
+                env: {
+                    ...process.env,
+                    // The repo root pins packageManager to Yarn; Corepack would
+                    // otherwise refuse to let npm run underneath it.
+                    COREPACK_ENABLE_STRICT: '0',
+                },
+            }
+        );
+    } finally {
+        // The committed package.json always points at the tarballs.
+        fs.writeFileSync(manifestPath, original);
+    }
 
     for (const [from, to] of VENDOR) {
         const source = path.join(cwd, 'node_modules', from);

--- a/packages/integration/tests/browser.spec.js
+++ b/packages/integration/tests/browser.spec.js
@@ -18,6 +18,7 @@ const PAGES = [
     ['C4', `${VANILLA}/umd-chart.html`, 'per-chart UMD build through a bundler', { bars: true }],
     ['C5', `${VANILLA}/esm-bundle.html`, 'ES modules (package module entry)', { bars: true }],
     ['C6', `${VANILLA}/esm-chart.html`, 'per-chart ES module by source path', { bars: true }],
+    ['CDN', `${VANILLA}/cdn-jsdelivr.html`, 'published version: CDN bundle from jsDelivr', { bars: true, published: true }],
     ['R1–R2', `${REACT}/package.html`, 'React 19: named imports from @britecharts/react', { donut: true, line: true, react: true }],
     ['R3', `${REACT}/cjs-chart.html`, 'React 19: per-component CommonJS build', { donut: true, react: true }],
     ['R4', `${REACT}/umd-chart.html`, 'React 19: per-component UMD build', { donut: true, react: true }],
@@ -25,6 +26,11 @@ const PAGES = [
 
 for (const [id, url, how, expects] of PAGES) {
     test(`${id} · ${how}`, async ({ page }) => {
+        test.skip(
+            Boolean(expects.published) && !process.env.SMOKE_REGISTRY,
+            'needs a published version; run by smoke-published.yml'
+        );
+
         const problems = [];
 
         page.on('console', (message) => {


### PR DESCRIPTION
## Description

Phase 5, the last, of the integration package (#1036, #1037, #1038, #1039 before it): checking what actually shipped after a release, the remaining documentation, and retiring the three stand-alone test repos.

**`smoke-published.yml`** — a new workflow that tests the published packages rather than local tarballs. It runs after every successful **Release** run and on demand for any version or dist-tag (default `latest`). It resolves the version with `npm view` and stops with a notice if it is not on the registry (a Release run that only updated the "Version Packages" PR), otherwise it installs the consumers from npm and runs the require, types and browser tiers, plus a page that loads the CDN bundle and stylesheet from jsDelivr. It is the only workflow whose assertions touch the network, and it is never part of the PR job.

**Integration package**

- `scripts/install-consumers.js` gains a registry mode: `BRITECHARTS_SOURCE=registry BRITECHARTS_VERSION=<version>` rewrites each consumer's `file:` references to `@britecharts/*@<version>` for the duration of the `npm install` and always restores the committed manifest.
- `consumers/vanilla/cdn-jsdelivr.html` loads `core.cdn.min.js` and the CSS bundle from jsDelivr at `%VITE_BRITECHARTS_VERSION%` (Vite's HTML env substitution). `tests/browser.spec.js` skips it unless `SMOKE_REGISTRY` is set, so PR runs stay offline.
- `test:published` script: install from the registry → require → types → browser. No pack step and no tarball tier, since there is no tarball.
- README: how to run against a published version.

**Docs and links**

- Root `README.md` and `docs/Britecharts.md`: the "Test Project" header link now points at `packages/integration/consumers`. The migration guide's CommonJS/CDN pointer goes to the vanilla consumer. No reference to the three old repos remains in the monorepo.
- `CONTRIBUTING.md`: a "Running the Integration Tests" section.
- `MAINTAINING.md`: a "Releasing" section — the Changesets flow, **Integration** as a required check on `main`, Yarn's packer as the authoritative one (never verify publish contents with `npm pack`), and the smoke workflow after a publish.
- `.claude/README.md`: the `posttest` warning corrected (Yarn Berry never ran that hook) and how to run the integration tests.

**Outside this repo, not in this PR** — `britecharts-test-project`, `britecharts-react-test-project` and `britecharts-typescript-test-project` each have a prepared commit replacing their README with a pointer to `packages/integration` and the matching consumer. Pushing those and archiving the repos is a separate, manual step (audit item H9).

## Motivation and Context

Phases 1–4 test what *would* ship, from tarballs packed the way the release packs them. Until now nothing checked what *did* ship: that the tarball on npm installs, that the CDN files are where jsDelivr expects them, and that the typings resolve from the registry copy. This closes that loop and makes the release runbook say so.

Closes the "integrate the test projects" item from the working notes: audit items C5 (refresh the test project) and G2 (the stale satellite repos) are resolved by the integration package. Plan: `managing-docs/integration-test-package-plan.md` §10.

## How Has This Been Tested?

Node 24, macOS, no environment flags.

- `yarn test:integration` (PR mode): tarball **21/21**, require **5/5**, types **2/2**, browser **9 passed, 1 skipped** (the jsDelivr page, as intended).
- Registry mode against the unpublished `3.0.0-beta.0`: npm fails with a clean 404, the consumer manifests are restored (`git status` clean), and a missing `BRITECHARTS_VERSION` is rejected with a message.
- `yarn lint:js` passes.
- The smoke workflow itself cannot run yet: nothing under `@britecharts` is published. Its first real run is the 3.0.0 beta (S3). The YAML parses; the version-resolution step was exercised locally by hand.

## Screenshots (if appropriate):

N/A

## Types of changes

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] Latest master code has been merged into this branch
-   [x] No commented out code (if required, place // TODO above with explanation)
-   [x] No linting issues
-   [x] Build is successful
-   [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [x] Updated the documentation
-   [x] Added tests to cover changes
-   [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wnD3atYJGPoq5JsmEDNbm
