### PR TITLE
chore: fixing chromatic

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,6 +35,22 @@ jobs:
       - name: Build docs website 📚
         run: yarn docs:build
 
+      # The Storybooks live under /storybook/ on the same site: the composed
+      # shell at /storybook/, and the two it references at /storybook/core
+      # and /storybook/react. Same origin, so composition needs no CORS and
+      # no login -- which is what publishing them to Chromatic could not give.
+      - name: Build packages 🔧
+        run: yarn build:packages
+
+      - name: Build the Storybooks 📖
+        run: |
+          yarn workspace @britecharts/core demo:build
+          yarn workspace @britecharts/react demo:build
+          yarn workspace @britecharts/demos build
+
+      - name: Add the Storybooks to the site
+        run: node scripts/compose-site.js
+
       - name: Deploy to GitHub Pages 🚀
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/storybook-publish.yml
+++ b/.github/workflows/storybook-publish.yml
@@ -1,5 +1,11 @@
-name: Storybook Deployment to Chromatic
+name: Visual tests on Chromatic
 
+# Publishes the core and react Storybooks to Chromatic for visual review. The
+# composed demos Storybook is only *built* here, as a check: it has no stories
+# of its own (two MDX pages and two composition refs, which Chromatic never
+# snapshots), so Chromatic rejected it on every run with "Cannot run a build
+# with no stories". It is hosted on GitHub Pages instead, by docs-deploy.yml.
+#
 # Was `on: push` for every branch, which spent a Chromatic snapshot on every
 # commit anywhere in the repo.
 on:
@@ -61,12 +67,5 @@ jobs:
           autoAcceptChanges: 'main'
           storybookBuildDir: './packages/react/dist/storybook'
 
-      - name: Build main storybook 🔧
+      - name: Build the composed storybook (check only) 🔧
         run: yarn workspace @britecharts/demos build
-
-      - name: Publish main storybook to Chromatic 🚀
-        uses: chromaui/action@v18
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          autoAcceptChanges: 'main'
-          storybookBuildDir: './packages/demos/dist'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <span> · </span>
   <a href="https://github.com/britecharts/britecharts/tree/main/packages/integration/consumers">Test Projects</a>
   <span> · </span>
-  <a href="https://britecharts.github.io/britecharts/docs/tutorials/tutorials-index">Storybook</a>
+  <a href="https://britecharts.github.io/britecharts/storybook/">Storybook</a>
   <span> · </span>
   <a href="https://britecharts.github.io/britecharts/docs/how-tos/contributor-how-to-guides">Contribute</a>
   <br />

--- a/packages/demos/.storybook/main.js
+++ b/packages/demos/.storybook/main.js
@@ -48,14 +48,23 @@ module.exports = {
             };
         }
 
+        // Production: the three Storybooks are deployed together under
+        // /storybook/ on the docs site (see .github/workflows/docs-deploy.yml
+        // and scripts/compose-site.js), so the refs are same-origin -- no
+        // CORS, no login wall. Chromatic still receives core and react for
+        // visual review, but nothing public points at it.
+        const base =
+            process.env.STORYBOOK_REFS_BASE ||
+            'https://britecharts.github.io/britecharts/storybook';
+
         return {
             core: {
                 title: 'Britecharts Core',
-                url: 'https://main--63e47b02f004ed290364764f.chromatic.com',
+                url: `${base}/core`,
             },
             react: {
                 title: 'Britecharts React',
-                url: 'https://main--63e48c5ee9db838c66d19aae.chromatic.com',
+                url: `${base}/react`,
             },
         };
     },

--- a/packages/demos/README.md
+++ b/packages/demos/README.md
@@ -18,9 +18,9 @@ That starts core on 2001, react on 2002 and this shell on 2000 — open [localho
 If core and react are already running, `yarn demos:shell` brings up just this package. On its own it renders the shell with both refs unavailable, which is why the composed command is the default.
 
 
-You can see [here][demos] the production Storybook deployed.
+The production build is deployed with the docs site on every push to `main`, under [/storybook/][demos], together with the core and react Storybooks it composes (`/storybook/core`, `/storybook/react`). Composition there is same-origin, so it needs no CORS setup and no login.
 
 If you want to help completing these, check our [contributing guide][contributing] and get started collaborating with Britecharts.
 
-[demos]: **
+[demos]: https://britecharts.github.io/britecharts/storybook/
 [contributing]: https://github.com/britecharts/britecharts/blob/main/.github/CONTRIBUTING.md

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -10,7 +10,6 @@
     "@storybook/html-webpack5": "8.6.14",
     "@storybook/manager-api": "8.6.14",
     "@storybook/theming": "8.6.14",
-    "chromatic": "^6.15.0",
     "raw-loader": "^4.0.2",
     "react": "16.14.0",
     "react-dom": "16.14.0",
@@ -20,7 +19,6 @@
   },
   "scripts": {
     "build": "storybook build -c .storybook -o dist",
-    "chromatic": "chromatic --project-token=$CHROMATIC_TOKEN",
     "clean": "rimraf dist",
     "demo": "yarn storybook",
     "prebuild": "yarn run clean",

--- a/packages/docs/docs/Britecharts.md
+++ b/packages/docs/docs/Britecharts.md
@@ -23,7 +23,7 @@
   <span> · </span>
   <a href="https://github.com/britecharts/britecharts/tree/main/packages/integration/consumers">Test Projects</a>
   <span> · </span>
-  <a href="https://britecharts.github.io/britecharts/docs/tutorials/tutorials-index">Storybook</a>
+  <a href="https://britecharts.github.io/britecharts/storybook/">Storybook</a>
   <span> · </span>
   <a href="https://britecharts.github.io/britecharts/docs/how-tos/contributor-how-to-guides">Contribute</a>
   <br />

--- a/packages/docs/docs/storybook.md
+++ b/packages/docs/docs/storybook.md
@@ -3,3 +3,34 @@ sidebar_position: 7
 ---
 
 # Storybook
+
+Every chart and every React component has a Storybook story, and the stories
+are the demos: browse them at
+[britecharts.github.io/britecharts/storybook](https://britecharts.github.io/britecharts/storybook/).
+
+That page is a *composed* Storybook. It has an introduction and the changelog
+of its own, and pulls in two others as sections:
+
+| Section | Package | Direct link |
+|---|---|---|
+| Britecharts Core | `@britecharts/core` | [/storybook/core](https://britecharts.github.io/britecharts/storybook/core/) |
+| Britecharts React | `@britecharts/react` | [/storybook/react](https://britecharts.github.io/britecharts/storybook/react/) |
+
+All three are built and deployed with the documentation on every push to
+`main`, so they always show what is on `main`.
+
+## Running them locally
+
+```sh
+yarn demos
+```
+
+starts core on port 2001, React on 2002 and the composed shell on 2000. See
+the [contributing guide](https://github.com/britecharts/britecharts/blob/main/.github/CONTRIBUTING.md)
+for the details.
+
+## Visual review
+
+The core and React Storybooks are also published to Chromatic from every pull
+request, where maintainers review visual changes story by story. That is a
+review tool, not a public site: the links above are the ones to share.

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -60,7 +60,9 @@ module.exports = {
                         label: 'API Reference',
                     },
                     {
-                        href: 'https://main--63d6bf7d2876e82fb2534b93.chromatic.com',
+                        // Deployed next to the docs by docs-deploy.yml; pathname:// keeps
+                        // Docusaurus from treating it as a route of its own.
+                        href: 'pathname:///storybook/',
                         position: 'left',
                         label: 'StoryBook',
                     },

--- a/scripts/compose-site.js
+++ b/scripts/compose-site.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+// Copies the three built Storybooks into the docs site's build output so one
+// GitHub Pages deploy carries the documentation and the demos:
+//
+//   /storybook/        the composed shell (packages/demos)
+//   /storybook/core    @britecharts/core's Storybook
+//   /storybook/react   @britecharts/react's Storybook
+//
+// The shell's production refs point at those two paths (see
+// packages/demos/.storybook/main.js), so everything is same-origin.
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SITE = path.join(ROOT, 'packages/docs/build');
+const COPIES = [
+    ['packages/demos/dist', 'storybook'],
+    ['packages/core/dist/storybook', 'storybook/core'],
+    ['packages/react/dist/storybook', 'storybook/react'],
+];
+
+if (!fs.existsSync(path.join(SITE, 'index.html'))) {
+    console.error(
+        'packages/docs/build is missing; run `yarn docs:build` first.'
+    );
+    process.exit(1);
+}
+
+// The shell is copied first and the others into it, so copy order matters and
+// a stale /storybook from a previous run is removed rather than merged.
+fs.rmSync(path.join(SITE, 'storybook'), { recursive: true, force: true });
+
+for (const [from, to] of COPIES) {
+    const source = path.join(ROOT, from);
+
+    if (!fs.existsSync(path.join(source, 'index.html'))) {
+        console.error(`${from} has no index.html; build that Storybook first.`);
+        process.exit(1);
+    }
+    fs.cpSync(source, path.join(SITE, to), { recursive: true });
+    console.log(`${from} -> build/${to}`);
+}

--- a/scripts/wait-for-storybook-refs.js
+++ b/scripts/wait-for-storybook-refs.js
@@ -16,7 +16,7 @@
  * webpack build happened to finish first.
  *
  * Waiting here makes local behave the way production already does, where the
- * refs are Chromatic URLs that are always up.
+ * refs are the GitHub Pages copies deployed with the docs, always up.
  *
  * Usage: node scripts/wait-for-storybook-refs.js <url>... -- <command> [args]
  */
@@ -77,7 +77,9 @@ const waitForAll = async () => {
             // shell still works on its own, the missing refs just will not load.
             console.warn(
                 `[refs] gave up waiting for ${[...pending].join(', ')} after ` +
-                    `${TIMEOUT_MS / 1000}s -- starting anyway, those refs will ` +
+                    `${
+                        TIMEOUT_MS / 1000
+                    }s -- starting anyway, those refs will ` +
                     `not load`
             );
             break;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3453,7 +3453,6 @@ __metadata:
     "@storybook/html-webpack5": 8.6.14
     "@storybook/manager-api": 8.6.14
     "@storybook/theming": 8.6.14
-    chromatic: ^6.15.0
     raw-loader: ^4.0.2
     react: 16.14.0
     react-dom: 16.14.0


### PR DESCRIPTION
## Description

Makes the Chromatic workflow green for the first time in its history, and takes the Storybooks out from behind Chromatic's login wall with the same change (audit item F1).

**Why it was red.** The workflow's last step published the composed demos Storybook (`packages/demos`) to Chromatic, and Chromatic refuses any build with no stories:

```
✖ Failed to extract stories from your Storybook
  Cannot run a build with no stories. Please add some stories!
```

That Storybook has none by design: two MDX pages (Introduction, Changelog) and two composition refs pointing at the core and react Storybooks, which Chromatic never snapshots. Publishing it there was only ever hosting — and private hosting at that, since all three Chromatic permalinks return 401.

**The fix: host, don't snapshot.**

- `docs-deploy.yml` now builds the packages and the three Storybooks and runs the new `scripts/compose-site.js`, which copies them into the docs build before the GitHub Pages deploy. The composed shell lands at `/storybook/`, core at `/storybook/core` and react at `/storybook/react` on the docs site.
- `packages/demos/.storybook/main.js`: the production refs point at those two paths (overridable with `STORYBOOK_REFS_BASE`). Composition is same-origin now — no CORS middleware, no login — and nothing public points at Chromatic any more.
- `storybook-publish.yml` keeps publishing core and react to Chromatic, which is what it is for: visual review of the Storybooks that have stories. The demos Storybook is still *built* there as a check, but no longer published. `CHROMATIC_PROJECT_TOKEN` and the third Chromatic project are unused after this.
- Links: the docs navbar (`pathname:///storybook/`), the Storybook header link in the root README and its docs mirror, `docs/storybook.md` (rewritten to explain the three Storybooks and how to run them locally), and the demos README's `[demos]` placeholder. The demos package drops its `chromatic` script and devDependency; a stale comment in `scripts/wait-for-storybook-refs.js` is corrected.

## Motivation and Context

Two audit items in one: F1 (every published Storybook is behind a login wall) and the Chromatic job that has failed on every run. M11 had been recorded as "fix the README links and publish the Storybooks publicly", but only the links half had happened. After this, the demos are at a public URL that updates on every push to `main`, and Chromatic is scoped to the review job it is good at.

Audit rev 25 records the change and corrects M11.

## How Has This Been Tested?

Node 24, macOS.

- `yarn docs:build`, then `demo:build` for core and react and `build` for demos, then `node scripts/compose-site.js`: the site tree has `storybook/` (42 MB, the shell), `storybook/core` (15 MB) and `storybook/react` (15 MB), each with an `index.html`.
- The shell's built `index.html` carries the two GitHub Pages ref URLs; the only `chromatic.com` strings left in the build are inside Storybook's own manager runtime.
- The built docs' navbar link resolves to `/britecharts/storybook/`.
- The Chromatic job on this PR is the first run without the demos publish step; the docs deploy path runs on merge to `main`.

Not verifiable before merge: the live GitHub Pages deploy itself. The Chromatic job on PRs already performs the same three Storybook builds, so the only new step at deploy time is the copy.

## Screenshots (if appropriate):

N/A

## Types of changes

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] Latest master code has been merged into this branch
-   [x] No commented out code (if required, place // TODO above with explanation)
-   [x] No linting issues
-   [x] Build is successful
-   [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [x] Updated the documentation
-   [ ] Added tests to cover changes (CI configuration; the Chromatic and docs-deploy jobs are the test)
-   [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wnD3atYJGPoq5JsmEDNbm
