### PR TITLE
chore: grid helper rollout

### DIFF
--- a/.changeset/grid-helper-extended-line-and-highlight.md
+++ b/.changeset/grid-helper-extended-line-and-highlight.md
@@ -1,0 +1,18 @@
+---
+"@britecharts/core": patch
+---
+
+The grid helper now draws the axis baseline and the zero-line highlight
+itself. `gridHorizontal` and `gridVertical` gain `extendedLine(inset)` -- the
+solid line at the start of the scale's range that every chart drew by hand,
+inset by the room left for axis labels -- and `highlight(value)`, which adds
+`horizontal-grid-line--highlighted` (or the new `vertical-grid-line--highlighted`)
+to the grid line at that tick; the 2D `grid` gets `extendedLineH/V` and
+`highlightH/V`. Bar, grouped bar, stacked bar, scatter plot, line and stacked
+area use them in place of six copies of the same code, which also fixes two
+things: the baseline is now updated on every render instead of being drawn
+once and left stale after a resize, and the zero highlight is cleared again
+when the data stops crossing zero. The JSDoc types the helper documented as
+`*` are now named, and the H/V versus X/Y naming is written down. No visual
+change; the extended line moved from the grid group's parent into the grid
+group itself.

--- a/packages/core/src/charts/bar/bar.js
+++ b/packages/core/src/charts/bar/bar.js
@@ -822,11 +822,10 @@ export default function module() {
         const grid = gridVertical(xScale)
             .range([0, chartHeight])
             .hideEdges('first')
-            .ticks(xTicks);
+            .ticks(xTicks)
+            .extendedLine(xAxisPadding.bottom);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawVerticalExtendedLine();
     }
 
     /**
@@ -838,23 +837,6 @@ export default function module() {
     }
 
     /**
-     * Draws a vertical line to extend y-axis till the edges
-     * @return {void}
-     */
-    function drawVerticalExtendedLine() {
-        svg.select('.grid-lines-group')
-            .selectAll('line.extended-y-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-y-line')
-            .attr('y1', xAxisPadding.bottom)
-            .attr('y2', chartHeight)
-            .attr('x1', 0)
-            .attr('x2', 0);
-    }
-
-    /**
      * Draws the grid lines for a vertical bar chart
      * @return {void}
      */
@@ -862,28 +844,10 @@ export default function module() {
         const grid = gridHorizontal(yScale)
             .range([0, chartWidth])
             .hideEdges('first')
-            .ticks(yTicks);
+            .ticks(yTicks)
+            .extendedLine(xAxisPadding.left);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawHorizontalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend x-axis till the edges
-     * @return {void}
-     */
-    function drawHorizontalExtendedLine() {
-        svg.select('.grid-lines-group')
-            .selectAll('line.extended-x-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-x-line')
-            .attr('x1', xAxisPadding.left)
-            .attr('x2', chartWidth)
-            .attr('y1', chartHeight)
-            .attr('y2', chartHeight);
     }
 
     /**

--- a/packages/core/src/charts/grouped-bar/grouped-bar.js
+++ b/packages/core/src/charts/grouped-bar/grouped-bar.js
@@ -87,7 +87,6 @@ export default function module() {
         },
         yTicks = 5,
         xTicks = 5,
-        baseLine,
         colorSchema = colorHelper.colorSchemas.britecharts,
         nameToColorMap = null,
         colorScale,
@@ -426,47 +425,11 @@ export default function module() {
     }
 
     /**
-     * Draws a vertical line to extend x-axis till the edges
-     * @return {void}
-     */
-    function drawHorizontalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-x-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-x-line')
-            .attr('x1', xAxisPadding.left)
-            .attr('x2', chartWidth)
-            .attr('y1', chartHeight)
-            .attr('y2', chartHeight);
-    }
-
-    /**
      * Draws the loading state
      * @private
      */
     function drawLoadingState() {
         svg.select('.loading-state-group').html(barLoadingMarkup);
-    }
-
-    /**
-     * Draws a vertical line to extend y-axis till the edges
-     * @return {void}
-     */
-    function drawVerticalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-y-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-y-line')
-            .attr('y1', xAxisPadding.bottom)
-            .attr('y2', chartHeight)
-            .attr('x1', 0)
-            .attr('x2', 0);
     }
 
     /**
@@ -542,11 +505,10 @@ export default function module() {
         const grid = gridHorizontal(yScale)
             .range([0, chartWidth])
             .hideEdges('first')
-            .ticks(yTicks);
+            .ticks(yTicks)
+            .extendedLine(xAxisPadding.left);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawHorizontalExtendedLine();
     }
 
     /**
@@ -599,11 +561,10 @@ export default function module() {
         const grid = gridVertical(xScale)
             .range([0, chartHeight])
             .hideEdges('first')
-            .ticks(xTicks);
+            .ticks(xTicks)
+            .extendedLine(xAxisPadding.bottom);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawVerticalExtendedLine();
     }
 
     /**

--- a/packages/core/src/charts/helpers/grid.js
+++ b/packages/core/src/charts/helpers/grid.js
@@ -1,5 +1,21 @@
-// TODO: Document d3 objects rather than using *
-// TODO: Add bi-directional accessors for 2d grid, and determine naming (H/V vs. X/Y)
+/**
+ * A d3 scale with a numeric range: continuous (`scaleLinear`, `scaleTime`, ...)
+ * or band (`scaleBand`, `scalePoint`). Band scales are recognised through
+ * `bandwidth()` and their lines are centred on the band.
+ * @typedef {function} GridScale
+ */
+
+/**
+ * A d3 selection to render into, or a d3 transition on one. Given a
+ * transition, entering and exiting lines fade and slide between positions.
+ * @typedef {Object} GridContext
+ */
+
+// Naming: H and V describe the lines a grid draws -- horizontal lines come
+// from the y-scale's ticks, vertical lines from the x-scale's -- while X and Y
+// name scales and axes. So gridHorizontal(yScale) draws horizontal lines, and
+// on the 2D grid ticksH() sets the ticks of the horizontal lines, which are
+// taken from scaleY().
 
 const { scaleLinear } = require('d3-scale');
 const { classArray } = require('./classes');
@@ -21,7 +37,7 @@ const DIR = {
 /**
  * Higher order function that returns the default positioning function for continuous scales
  * The +0.5 avoids anti-aliasing artifacts
- * @param {*} scale - Scale for positioning
+ * @param {GridScale} scale - Scale for positioning
  * @return {function}
  * @private
  */
@@ -32,7 +48,7 @@ function positionNumber(scale) {
 /**
  * Higher order function that returns the positioning function for bandwidth scales
  * Also adjusted for anti-aliasing
- * @param {*} scale - Scale for positioning
+ * @param {GridScale} scale - Scale for positioning
  * @return {function}
  * @private
  */
@@ -49,7 +65,7 @@ function positionCenter(scale) {
 /**
  * Constructor for a one-dimensional grid helper
  * @param {string} orient - orientation string to define the direction
- * @param {*} scale - d3 scale for the grid's ticks
+ * @param {GridScale} scale - d3 scale for the grid's ticks
  * @return {gridBaseGenerator}
  * @private
  */
@@ -60,6 +76,8 @@ function gridBase(orient, scale) {
         hideEdges = false,
         ticks = null,
         tickValues = null,
+        extendedLine = null,
+        highlight = null,
         // Create a class array helper for producing class lists
         classArr = classArray(COMPONENT_CLASSNAME, orient),
         // Manage horizontal and vertical directions by setting the a parameter
@@ -69,7 +87,7 @@ function gridBase(orient, scale) {
 
     /**
      * Generator function for one-dimensional grid
-     * @param {*} context - d3 selection or transition to use as the container
+     * @param {GridContext} context - d3 selection or transition to use as the container
      */
     function gridBaseGenerator(context) {
         let values = getValues(),
@@ -93,11 +111,21 @@ function gridBase(orient, scale) {
                     .attr('class', classArr.asList())
             ),
             // Set up line selections
-            line = container.selectAll('line').data(values, scale).order(),
+            // Scoped to the grid lines: the extended line shares the container
+            line = container
+                .selectAll('line.grid-line')
+                .data(values, scale)
+                .order(),
             lineExit = line.exit(),
             lineEnter = line.enter().append('line').attr('class', 'grid-line');
 
-        line = line.merge(lineEnter);
+        line = line
+            .merge(lineEnter)
+            .attr('class', (d) =>
+                highlight !== null && d === highlight
+                    ? `grid-line ${orient}-grid-line--highlighted`
+                    : 'grid-line'
+            );
 
         // Run animations only if grid was called on a transition
         if (context !== selection) {
@@ -140,6 +168,8 @@ function gridBase(orient, scale) {
             .attr(y + '1', (d) => position(d))
             .attr(y + '2', (d) => position(d));
 
+        drawExtendedLine(container, k);
+
         // Attach the positioning function as a property of the container element
         // This stores it for future use as the starting point for the lineEnter transition
         // Cannot use arrow function as this must refer to the element
@@ -149,6 +179,35 @@ function gridBase(orient, scale) {
     }
 
     // HELPERS
+
+    /**
+     * Draws (or removes) the extended line: the axis baseline, a solid line
+     * at the start of the scale's own range, spanning the grid's range. It is
+     * inset from the start of that range by the extendedLine offset, which is
+     * where a chart leaves room for its axis labels.
+     * @param {GridContext} container - the grid's container group
+     * @param {number} k - 1 or -1, the direction of the range
+     * @private
+     */
+    function drawExtendedLine(container, k) {
+        const className = `extended-${x}-line`;
+        const extended = container
+            .selectAll(`line.${className}`)
+            .data(extendedLine === null ? [] : [null]);
+        const at = +scale.range()[0];
+
+        extended.exit().remove();
+
+        extended
+            .enter()
+            .append('line')
+            .attr('class', className)
+            .merge(extended)
+            .attr(x + '1', +range[0] + k * extendedLine)
+            .attr(x + '2', +range[range.length - 1])
+            .attr(y + '1', at)
+            .attr(y + '2', at);
+    }
 
     /**
      * Extract the tick values and adjust for edge hiding
@@ -194,8 +253,8 @@ function gridBase(orient, scale) {
     /**
      * Gets or sets the scale
      * Scale applies the ticks to the grid
-     * @param {*} [_] - d3 scale instance
-     * @return {*|gridBaseGenerator}
+     * @param {GridScale} [_] - d3 scale instance
+     * @return {GridScale|gridBaseGenerator}
      * @public
      */
     gridBaseGenerator.scale = function (_) {
@@ -212,7 +271,7 @@ function gridBase(orient, scale) {
      * Governs the underlying length and positioning of the grid lines relative to the container
      * Should usually be set to the output range from the orthogonal scale in a 2D chart
      * @param {number[]} [_] - Array representing the output range
-     * @return {*|gridBaseGenerator}
+     * @return {number[]|gridBaseGenerator}
      * @public
      */
     gridBaseGenerator.range = function (_) {
@@ -228,7 +287,7 @@ function gridBase(orient, scale) {
      * Gets or sets the start offset
      * Start offset is the distance before the start position of the scale's range that the grid will render
      * @param {number} [_] - Offset in px
-     * @return {*|gridBaseGenerator}
+     * @return {GridScale|gridBaseGenerator}
      * @public
      */
     gridBaseGenerator.offsetStart = function (_) {
@@ -244,7 +303,7 @@ function gridBase(orient, scale) {
      * Gets or sets the end offset
      * End offset is the distance after the end position of the scale's range that the grid will render
      * @param {number} [_] - Offset in px
-     * @return {*|gridBaseGenerator}
+     * @return {GridScale|gridBaseGenerator}
      * @public
      */
     gridBaseGenerator.offsetEnd = function (_) {
@@ -306,13 +365,54 @@ function gridBase(orient, scale) {
         return gridBaseGenerator;
     };
 
+    /**
+     * Gets or sets the extended line offset
+     * The extended line is the axis baseline: a solid line at the start of the
+     * scale's range, spanning the grid's range. A number draws it, inset by
+     * that many px from the start of the range (room for the axis labels);
+     * null, the default, draws none. The line carries the class
+     * `extended-x-line` on a horizontal grid and `extended-y-line` on a
+     * vertical one.
+     * @param {number|null} [_] - Inset in px, or null for no line
+     * @return {number|null|gridBaseGenerator}
+     * @public
+     */
+    gridBaseGenerator.extendedLine = function (_) {
+        if (!arguments.length) {
+            return extendedLine;
+        }
+        extendedLine = _;
+
+        return gridBaseGenerator;
+    };
+
+    /**
+     * Gets or sets the highlighted tick value
+     * The grid line drawn at this value (typically 0, when the data crosses it)
+     * also gets the class `horizontal-grid-line--highlighted` or
+     * `vertical-grid-line--highlighted`. Only a line that exists is
+     * highlighted, so the value must be one of the ticks. null, the default,
+     * highlights nothing.
+     * @param {number|Date|string|null} [_] - Tick value to highlight, or null
+     * @return {number|Date|string|null|gridBaseGenerator}
+     * @public
+     */
+    gridBaseGenerator.highlight = function (_) {
+        if (!arguments.length) {
+            return highlight;
+        }
+        highlight = _;
+
+        return gridBaseGenerator;
+    };
+
     return gridBaseGenerator;
 }
 
 /**
  * Constructor for a two-dimensional grid helper
- * @param {*} scaleX - d3 scale for the grid's x direction
- * @param {*} scaleY - d3 scale for the grid's y direction
+ * @param {GridScale} scaleX - d3 scale for the grid's x direction
+ * @param {GridScale} scaleY - d3 scale for the grid's y direction
  * @return {gridGenerator}
  * @memberof Grid
  * @alias module:Grid.grid
@@ -333,7 +433,7 @@ export function grid(scaleX, scaleY) {
 
     /**
      * Generator function for two-dimensional grid
-     * @param {*} context - d3 selection or transition to use as the container
+     * @param {GridContext} context - d3 selection or transition to use as the container
      */
     function gridGenerator(context) {
         direction === DIRECTION_FULL || direction === DIRECTION_HORIZONTAL
@@ -352,8 +452,8 @@ export function grid(scaleX, scaleY) {
     /**
      * Gets or sets the x-scale
      * X-scale applies ticks to the vertical grid and range to the horizontal grid
-     * @param {*} [_] - d3 scale instance
-     * @return {*|gridGenerator}
+     * @param {GridScale} [_] - d3 scale instance
+     * @return {GridScale|gridGenerator}
      * @public
      */
     gridGenerator.scaleX = function (_) {
@@ -369,8 +469,8 @@ export function grid(scaleX, scaleY) {
     /**
      * Gets or sets the y-scale
      * Y-scale applies ticks to the horizontal grid and range to the vertical grid
-     * @param {*} [_] - d3 scale instance
-     * @return {*|gridGenerator}
+     * @param {GridScale} [_] - d3 scale instance
+     * @return {GridScale|gridGenerator}
      * @public
      */
     gridGenerator.scaleY = function (_) {
@@ -661,12 +761,76 @@ export function grid(scaleX, scaleY) {
         return gridGenerator;
     };
 
+    /**
+     * Gets or sets the extended line offset of the horizontal grid
+     * See gridHorizontal's extendedLine
+     * @param {number|null} [_] - Inset in px, or null for no line
+     * @return {number|null|gridGenerator}
+     * @public
+     */
+    gridGenerator.extendedLineH = function (_) {
+        if (!arguments.length) {
+            return gridH.extendedLine();
+        }
+        gridH.extendedLine(_);
+
+        return gridGenerator;
+    };
+
+    /**
+     * Gets or sets the extended line offset of the vertical grid
+     * See gridVertical's extendedLine
+     * @param {number|null} [_] - Inset in px, or null for no line
+     * @return {number|null|gridGenerator}
+     * @public
+     */
+    gridGenerator.extendedLineV = function (_) {
+        if (!arguments.length) {
+            return gridV.extendedLine();
+        }
+        gridV.extendedLine(_);
+
+        return gridGenerator;
+    };
+
+    /**
+     * Gets or sets the highlighted tick value of the horizontal grid
+     * See gridHorizontal's highlight
+     * @param {number|Date|string|null} [_] - Tick value to highlight, or null
+     * @return {number|Date|string|null|gridGenerator}
+     * @public
+     */
+    gridGenerator.highlightH = function (_) {
+        if (!arguments.length) {
+            return gridH.highlight();
+        }
+        gridH.highlight(_);
+
+        return gridGenerator;
+    };
+
+    /**
+     * Gets or sets the highlighted tick value of the vertical grid
+     * See gridVertical's highlight
+     * @param {number|Date|string|null} [_] - Tick value to highlight, or null
+     * @return {number|Date|string|null|gridGenerator}
+     * @public
+     */
+    gridGenerator.highlightV = function (_) {
+        if (!arguments.length) {
+            return gridV.highlight();
+        }
+        gridV.highlight(_);
+
+        return gridGenerator;
+    };
+
     return gridGenerator;
 }
 
 /**
  * Constructor for a horizontal grid helper
- * @param {*} scale - d3 scale to initialize the grid
+ * @param {GridScale} scale - d3 scale to initialize the grid
  * @return {gridBaseGenerator}
  * @public
  * @memberof Grid
@@ -685,7 +849,7 @@ export function gridHorizontal(scale) {
 
 /**
  * Constructor for a vertical grid helper
- * @param {*} scale - d3 scale to initialize the grid
+ * @param {GridScale} scale - d3 scale to initialize the grid
  * @return {gridBaseGenerator}
  * @public
  * @memberof Grid
@@ -705,6 +869,11 @@ export function gridVertical(scale) {
 /**
  * Reusable Grid component helper that renders either a vertical, horizontal or full grid, and that
  * will usually be used inside charts. It could also be used as a standalone component to use on custom charts.
+ *
+ * Naming: H and V describe the lines a grid draws, X and Y name scales.
+ * gridHorizontal(yScale) draws horizontal lines from the y-scale's ticks; on
+ * the 2D grid, ticksH() sets the ticks of the horizontal lines (from scaleY())
+ * and ticksV() those of the vertical lines (from scaleX()).
  * @module Grid
  * @requires d3-scale
  * @exports gridHorizontal

--- a/packages/core/src/charts/helpers/grid.spec.js
+++ b/packages/core/src/charts/helpers/grid.spec.js
@@ -1,0 +1,162 @@
+import { select } from 'd3-selection';
+import { scaleBand, scaleLinear } from 'd3-scale';
+
+import { grid, gridHorizontal, gridVertical } from './grid';
+
+describe('grid helper', () => {
+    let container;
+
+    const yScale = () => scaleLinear().domain([0, 10]).range([100, 0]);
+    const xScale = () => scaleLinear().domain([0, 4]).range([0, 200]);
+    const lines = (selector) => container.selectAll(selector).nodes();
+
+    beforeEach(() => {
+        container = select(document.body)
+            .append('svg')
+            .append('g')
+            .attr('class', 'grid-lines-group');
+    });
+
+    afterEach(() => {
+        select(document.body).selectAll('svg').remove();
+    });
+
+    describe('gridHorizontal', () => {
+        it('draws one horizontal line per tick, in a grid container', () => {
+            gridHorizontal(yScale()).range([0, 200]).ticks(5)(container);
+
+            expect(lines('g.grid.horizontal')).toHaveLength(1);
+            expect(lines('line.grid-line')).toHaveLength(6);
+            expect(lines('line.grid-line')[0].getAttribute('x2')).toBe('200');
+        });
+
+        it('hides the first edge when asked', () => {
+            gridHorizontal(yScale())
+                .range([0, 200])
+                .ticks(5)
+                .hideEdges('first')(container);
+
+            expect(lines('line.grid-line')).toHaveLength(5);
+        });
+
+        it('draws no extended line by default', () => {
+            gridHorizontal(yScale()).range([0, 200])(container);
+
+            expect(lines('line.extended-x-line')).toHaveLength(0);
+        });
+
+        it('draws the extended line at the start of its own range, inset by the offset', () => {
+            gridHorizontal(yScale()).range([0, 200]).extendedLine(30)(
+                container
+            );
+
+            const [extended] = lines(
+                'g.grid.horizontal > line.extended-x-line'
+            );
+
+            expect(extended).toBeDefined();
+            expect(extended.getAttribute('x1')).toBe('30');
+            expect(extended.getAttribute('x2')).toBe('200');
+            expect(extended.getAttribute('y1')).toBe('100');
+            expect(extended.getAttribute('y2')).toBe('100');
+        });
+
+        it('updates the extended line on re-render and removes it when set back to null', () => {
+            const g = gridHorizontal(yScale()).range([0, 200]).extendedLine(0);
+
+            g(container);
+            g.range([0, 300])(container);
+            expect(lines('line.extended-x-line')).toHaveLength(1);
+            expect(lines('line.extended-x-line')[0].getAttribute('x2')).toBe(
+                '300'
+            );
+
+            g.extendedLine(null)(container);
+            expect(lines('line.extended-x-line')).toHaveLength(0);
+        });
+
+        it('highlights the line at the given tick value', () => {
+            gridHorizontal(scaleLinear().domain([-5, 5]).range([100, 0]))
+                .range([0, 200])
+                .ticks(5)
+                .highlight(0)(container);
+
+            const highlighted = lines('line.horizontal-grid-line--highlighted');
+
+            expect(highlighted).toHaveLength(1);
+            expect(highlighted[0].__data__).toBe(0);
+            expect(highlighted[0].classList.contains('grid-line')).toBe(true);
+        });
+
+        it('clears the highlight on re-render when it is set back to null', () => {
+            const g = gridHorizontal(
+                scaleLinear().domain([-5, 5]).range([100, 0])
+            )
+                .range([0, 200])
+                .ticks(5)
+                .highlight(0);
+
+            g(container);
+            g.highlight(null)(container);
+
+            expect(
+                lines('line.horizontal-grid-line--highlighted')
+            ).toHaveLength(0);
+            // d3 ticks(5) on [-5, 5] gives -4, -2, 0, 2, 4
+            expect(lines('line.grid-line')).toHaveLength(5);
+        });
+    });
+
+    describe('gridVertical', () => {
+        it('draws vertical lines and names the extended line and highlight after its direction', () => {
+            gridVertical(xScale())
+                .range([0, 100])
+                .ticks(4)
+                .extendedLine(10)
+                .highlight(0)(container);
+
+            const [extended] = lines('g.grid.vertical > line.extended-y-line');
+
+            expect(lines('line.grid-line').length).toBeGreaterThan(0);
+            expect(extended.getAttribute('y1')).toBe('10');
+            expect(extended.getAttribute('y2')).toBe('100');
+            expect(extended.getAttribute('x1')).toBe('0');
+            expect(extended.getAttribute('x2')).toBe('0');
+            expect(lines('line.vertical-grid-line--highlighted')).toHaveLength(
+                1
+            );
+        });
+
+        it('centres its lines on band scales', () => {
+            const band = scaleBand().domain(['a', 'b']).range([0, 100]);
+
+            gridVertical(band).range([0, 50])(container);
+
+            expect(lines('line.grid-line')[0].getAttribute('x1')).toBe('25');
+        });
+    });
+
+    describe('grid (2D)', () => {
+        it('passes extendedLine and highlight through to each direction', () => {
+            const g = grid(xScale(), yScale())
+                .extendedLineH(20)
+                .extendedLineV(5)
+                .highlightH(0)
+                .highlightV(0);
+
+            g(container);
+
+            expect(g.extendedLineH()).toBe(20);
+            expect(g.extendedLineV()).toBe(5);
+            expect(g.highlightH()).toBe(0);
+            expect(lines('line.extended-x-line')).toHaveLength(1);
+            expect(lines('line.extended-y-line')).toHaveLength(1);
+            expect(
+                lines('line.horizontal-grid-line--highlighted')
+            ).toHaveLength(1);
+            expect(lines('line.vertical-grid-line--highlighted')).toHaveLength(
+                1
+            );
+        });
+    });
+});

--- a/packages/core/src/charts/line/line.js
+++ b/packages/core/src/charts/line/line.js
@@ -224,8 +224,6 @@ export default function module() {
         customLines = [],
         defaultCustomLineColor = colorHelper.colorSchemas.grey[3],
         grid = null,
-        baseLineX,
-        baseLineY,
         pathYCache = {},
         // extractors
         getDate = ({ date }) => date,
@@ -783,7 +781,6 @@ export default function module() {
 
     /**
      * Draws grid lines on the background of the chart
-     * TODO: Refactor into new grid helper
      * @return void
      */
     function drawGridLines(xTicks, yTicks) {
@@ -793,10 +790,7 @@ export default function module() {
         let shouldHighlightXAxis = minY < 0;
 
         if (grid === 'horizontal' || grid === 'full') {
-            drawHorizontalGridLines(yTicks);
-            if (shouldHighlightXAxis) {
-                drawHorizontalHighlightLine();
-            }
+            drawHorizontalGridLines(yTicks, shouldHighlightXAxis);
         }
 
         if (grid === 'vertical' || grid === 'full') {
@@ -814,29 +808,10 @@ export default function module() {
         const grid = gridVertical(xScale)
             .range([0, chartHeight])
             .hideEdges('first')
-            .ticks(xTicks);
+            .ticks(xTicks)
+            .extendedLine(xAxisPadding.bottom);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawVerticalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend y-axis till the edges
-     * @return {void}
-     */
-    function drawVerticalExtendedLine() {
-        baseLineY = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-y-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-y-line')
-            .attr('y1', xAxisPadding.bottom)
-            .attr('y2', chartHeight)
-            .attr('x1', 0)
-            .attr('x2', 0);
     }
 
     /**
@@ -845,51 +820,15 @@ export default function module() {
      * @return {void}
      * @private
      */
-    function drawHorizontalGridLines(yTicks) {
+    function drawHorizontalGridLines(yTicks, highlightZero = false) {
         const grid = gridHorizontal(yScale)
             .range([0, chartWidth])
             .hideEdges('first')
-            .ticks(yTicks);
+            .ticks(yTicks)
+            .extendedLine(0)
+            .highlight(highlightZero ? 0 : null);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawHorizontalExtendedLine();
-    }
-
-    /**
-     * Draws a horizontal line to extend x-axis till the edges
-     * @return {void}
-     * @private
-     */
-    function drawHorizontalExtendedLine() {
-        baseLineX = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-x-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-x-line')
-            .attr('x1', 0)
-            .attr('x2', chartWidth)
-            .attr('y1', chartHeight)
-            .attr('y2', chartHeight);
-    }
-
-    /**
-     * Adds highlight class to horizontal grid line at data = 0
-     * @return {void}
-     * @private
-     */
-    function drawHorizontalHighlightLine() {
-        const horizontalGrid = svg
-            .select('.horizontal')
-            .selectAll('.grid-line');
-
-        horizontalGrid.attr('class', (d) =>
-            d === 0
-                ? 'grid-line horizontal-grid-line--highlighted'
-                : 'grid-line'
-        );
     }
 
     /**

--- a/packages/core/src/charts/scatter-plot/scatter-plot.js
+++ b/packages/core/src/charts/scatter-plot/scatter-plot.js
@@ -95,7 +95,6 @@ export default function module() {
         tickPadding = 5,
         hollowColor = '#fff',
         grid = null,
-        baseLine,
         maskGridLines,
         delaunayMesh,
         xAxis,
@@ -605,29 +604,10 @@ export default function module() {
         const grid = gridVertical(xScale)
             .range([0, chartHeight])
             .hideEdges('first')
-            .ticks(xTicks);
+            .ticks(xTicks)
+            .extendedLine(xAxisPadding.bottom);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawVerticalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend y-axis till the edges
-     * @return {void}
-     */
-    function drawVerticalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-y-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-y-line')
-            .attr('y1', xAxisPadding.bottom)
-            .attr('y2', chartHeight)
-            .attr('x1', 0)
-            .attr('x2', 0);
     }
 
     /**
@@ -755,25 +735,6 @@ export default function module() {
     }
 
     /**
-     * Draws a vertical line to extend x-axis till the edges
-     * @return {void}
-     * @private
-     */
-    function drawHorizontalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-x-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-x-line')
-            .attr('x1', xAxisPadding.left)
-            .attr('x2', chartWidth)
-            .attr('y1', chartHeight)
-            .attr('y2', chartHeight);
-    }
-
-    /**
      * Draw horizontal gridles of the chart
      * These gridlines are parallel to x-axis
      * @return {void}
@@ -783,11 +744,10 @@ export default function module() {
         const grid = gridHorizontal(yScale)
             .range([0, chartWidth])
             .hideEdges('first')
-            .ticks(yTicks);
+            .ticks(yTicks)
+            .extendedLine(xAxisPadding.left);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawHorizontalExtendedLine();
     }
 
     /**

--- a/packages/core/src/charts/stacked-area/stacked-area.js
+++ b/packages/core/src/charts/stacked-area/stacked-area.js
@@ -116,7 +116,6 @@ export default function module() {
         xTicks = null,
         xAxisCustomFormat = null,
         locale,
-        baseLine,
         areaCurve = 'monotoneX',
         layers,
         series,
@@ -724,7 +723,6 @@ export default function module() {
 
     /**
      * Draws grid lines on the background of the chart
-     * TODO: Refactor into new grid helper
      * @return void
      */
     function drawGridLines() {
@@ -733,10 +731,7 @@ export default function module() {
         let shouldHighlightXAxis = getMinYAxisScale() < 0;
 
         if (grid === 'horizontal' || grid === 'full') {
-            drawHorizontalGridLines();
-            if (shouldHighlightXAxis) {
-                drawHorizontalHighlightLine();
-            }
+            drawHorizontalGridLines(shouldHighlightXAxis);
         }
 
         if (grid === 'vertical' || grid === 'full') {
@@ -748,49 +743,15 @@ export default function module() {
      * Draws the grid lines for a vertical bar chart
      * @return {void}
      */
-    function drawHorizontalGridLines() {
+    function drawHorizontalGridLines(highlightZero = false) {
         const grid = gridHorizontal(yScale)
             .range([0, chartWidth])
             .hideEdges('first')
-            .ticks(yTicks);
+            .ticks(yTicks)
+            .extendedLine(0)
+            .highlight(highlightZero ? 0 : null);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawHorizontalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend x-axis till the edges
-     * @return {void}
-     */
-    function drawHorizontalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-x-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-x-line')
-            .attr('x1', 0)
-            .attr('x2', chartWidth)
-            .attr('y1', chartHeight)
-            .attr('y2', chartHeight);
-    }
-
-    /**
-     * Adds highlight class to horizontal grid line at data = 0
-     * @return {void}
-     * @private
-     */
-    function drawHorizontalHighlightLine() {
-        const horizontalGrid = svg
-            .select('.horizontal')
-            .selectAll('.grid-line');
-        horizontalGrid.attr('class', (d) =>
-            d === 0
-                ? 'grid-line horizontal-grid-line--highlighted'
-                : 'grid-line'
-        );
     }
 
     /**
@@ -801,29 +762,10 @@ export default function module() {
         const grid = gridVertical(xScale)
             .range([0, chartHeight])
             .hideEdges('first')
-            .ticks(xTicks);
+            .ticks(xTicks)
+            .extendedLine(xAxisPadding.bottom);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawVerticalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend y-axis till the edges
-     * @return {void}
-     */
-    function drawVerticalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-y-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-y-line')
-            .attr('y1', xAxisPadding.bottom)
-            .attr('y2', chartHeight)
-            .attr('x1', 0)
-            .attr('x2', 0);
     }
 
     /**

--- a/packages/core/src/charts/stacked-bar/stacked-bar.js
+++ b/packages/core/src/charts/stacked-bar/stacked-bar.js
@@ -106,7 +106,6 @@ export default function module() {
         yAxisLabel,
         yAxisLabelEl,
         yAxisLabelOffset = -60,
-        baseLine,
         xAxisPadding = {
             top: 0,
             left: 0,
@@ -487,29 +486,10 @@ export default function module() {
         const grid = gridHorizontal(yScale)
             .range([0, chartWidth])
             .hideEdges('first')
-            .ticks(yTicks);
+            .ticks(yTicks)
+            .extendedLine(xAxisPadding.left);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawHorizontalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend x-axis till the edges
-     * @return {void}
-     */
-    function drawHorizontalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-x-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-x-line')
-            .attr('x1', xAxisPadding.left)
-            .attr('x2', chartWidth)
-            .attr('y1', chartHeight)
-            .attr('y2', chartHeight);
     }
 
     /**
@@ -559,29 +539,10 @@ export default function module() {
         const grid = gridVertical(xScale)
             .range([0, chartHeight])
             .hideEdges('first')
-            .ticks(xTicks);
+            .ticks(xTicks)
+            .extendedLine(xAxisPadding.bottom);
 
         grid(svg.select('.grid-lines-group'));
-
-        drawVerticalExtendedLine();
-    }
-
-    /**
-     * Draws a vertical line to extend y-axis till the edges
-     * @return {void}
-     */
-    function drawVerticalExtendedLine() {
-        baseLine = svg
-            .select('.grid-lines-group')
-            .selectAll('line.extended-y-line')
-            .data([0])
-            .enter()
-            .append('line')
-            .attr('class', 'extended-y-line')
-            .attr('y1', xAxisPadding.bottom)
-            .attr('y2', chartHeight)
-            .attr('x1', 0)
-            .attr('x2', 0);
     }
 
     /**

--- a/packages/core/src/styles/common/_grid.scss
+++ b/packages/core/src/styles/common/_grid.scss
@@ -8,7 +8,8 @@
     stroke-width: 1;
 }
 
-.horizontal-grid-line--highlighted {
+.horizontal-grid-line--highlighted,
+.vertical-grid-line--highlighted {
     stroke: $grey-700;
     stroke-dasharray: 2, 2;
 }

--- a/packages/docs/docs/API/grid.md
+++ b/packages/docs/docs/API/grid.md
@@ -1,8 +1,40 @@
+# Modules
+
+<dl>
+<dt><a href="#module_Grid">Grid</a></dt>
+<dd><p>Reusable Grid component helper that renders either a vertical, horizontal or full grid, and that
+will usually be used inside charts. It could also be used as a standalone component to use on custom charts.</p>
+<p>Naming: H and V describe the lines a grid draws, X and Y name scales.
+gridHorizontal(yScale) draws horizontal lines from the y-scale&#39;s ticks; on
+the 2D grid, ticksH() sets the ticks of the horizontal lines (from scaleY())
+and ticksV() those of the vertical lines (from scaleX()).</p>
+</dd>
+</dl>
+
+# Typedefs
+
+<dl>
+<dt><a href="#GridScale">GridScale</a> : <code>function</code></dt>
+<dd><p>A d3 scale with a numeric range: continuous (<code>scaleLinear</code>, <code>scaleTime</code>, ...)
+or band (<code>scaleBand</code>, <code>scalePoint</code>). Band scales are recognised through
+<code>bandwidth()</code> and their lines are centred on the band.</p>
+</dd>
+<dt><a href="#GridContext">GridContext</a> : <code>Object</code></dt>
+<dd><p>A d3 selection to render into, or a d3 transition on one. Given a
+transition, entering and exiting lines fade and slide between positions.</p>
+</dd>
+</dl>
+
 <a name="module_Grid"></a>
 
 # Grid
 Reusable Grid component helper that renders either a vertical, horizontal or full grid, and that
 will usually be used inside charts. It could also be used as a standalone component to use on custom charts.
+
+Naming: H and V describe the lines a grid draws, X and Y name scales.
+gridHorizontal(yScale) draws horizontal lines from the y-scale's ticks; on
+the 2D grid, ticksH() sets the ticks of the horizontal lines (from scaleY())
+and ticksV() those of the vertical lines (from scaleX()).
 
 **Requires**: <code>module:d3-scale</code>  
 
@@ -20,8 +52,8 @@ Constructor for a two-dimensional grid helper
 
 | Param | Type | Description |
 | --- | --- | --- |
-| scaleX | <code>\*</code> | d3 scale for the grid's x direction |
-| scaleY | <code>\*</code> | d3 scale for the grid's y direction |
+| scaleX | [<code>GridScale</code>](#GridScale) | d3 scale for the grid's x direction |
+| scaleY | [<code>GridScale</code>](#GridScale) | d3 scale for the grid's y direction |
 
 **Example**  
 ```js
@@ -42,7 +74,7 @@ Constructor for a horizontal grid helper
 
 | Param | Type | Description |
 | --- | --- | --- |
-| scale | <code>\*</code> | d3 scale to initialize the grid |
+| scale | [<code>GridScale</code>](#GridScale) | d3 scale to initialize the grid |
 
 **Example**  
 ```js
@@ -63,7 +95,7 @@ Constructor for a vertical grid helper
 
 | Param | Type | Description |
 | --- | --- | --- |
-| scale | <code>\*</code> | d3 scale to initialize the grid |
+| scale | [<code>GridScale</code>](#GridScale) | d3 scale to initialize the grid |
 
 **Example**  
 ```js
@@ -74,3 +106,18 @@ const grid = gridVertical(xScale)
 
     grid(svg.select('.grid-lines-group'));
 ```
+<a name="GridScale"></a>
+
+# GridScale : <code>function</code>
+A d3 scale with a numeric range: continuous (`scaleLinear`, `scaleTime`, ...)
+or band (`scaleBand`, `scalePoint`). Band scales are recognised through
+`bandwidth()` and their lines are centred on the band.
+
+**Kind**: global typedef  
+<a name="GridContext"></a>
+
+# GridContext : <code>Object</code>
+A d3 selection to render into, or a d3 transition on one. Given a
+transition, entering and exiting lines fade and slide between positions.
+
+**Kind**: global typedef  


### PR DESCRIPTION
## Description

Finishes the grid helper's own TODOs (audit item C4, grid half) and makes the six charts that use it stop drawing the same two things by hand.

**What the TODOs turned out to mean.** The two chart-side comments, "TODO: Refactor into new grid helper" in `line.js` and `stacked-area.js`, were stale: both charts already built their grids with `gridHorizontal`/`gridVertical` exactly the way `bar.js` does. The helper's own two TODOs were real: its d3 types were documented as `*`, and the axis baseline ("extended line") and the zero-line highlight were hand-drawn in six charts with the same fifteen lines each.

**`helpers/grid.js`**
- `GridScale` and `GridContext` typedefs replace every `*` in the JSDoc; they now render in the API docs with descriptions.
- The H/V-versus-X/Y naming is written down in the module doc: H and V describe the lines a grid draws (horizontal lines come from the y-scale's ticks), X and Y name scales. Nothing is renamed.
- Two new accessors on the one-dimensional grids. `extendedLine(inset)` draws the axis baseline: a solid line at the start of the scale's own range, spanning the grid's range, inset by the room left for axis labels; it carries `extended-x-line` on a horizontal grid and `extended-y-line` on a vertical one, as before. `highlight(value)` adds `horizontal-grid-line--highlighted` (or the new `vertical-grid-line--highlighted`) to the grid line at that tick. The 2D `grid` gets `extendedLineH/V` and `highlightH/V` in its existing style.
- The grid-line data join is scoped to `line.grid-line`, since the extended line now shares the grid's group.
- `helpers/grid.spec.js`: ten tests, the helper's first coverage.

**The six charts** — bar, grouped bar, stacked bar, scatter plot, line, stacked area — chain `.extendedLine(...)` (and, for line and stacked area, `.highlight(highlightZero ? 0 : null)`) and lose `drawHorizontalExtendedLine`, `drawVerticalExtendedLine`, `drawHorizontalHighlightLine` and their `baseLine` variables. Same insets as before: `xAxisPadding.left` / `xAxisPadding.bottom` on the bar-family charts and scatter plot, `0` horizontally on the time-series charts.

**Two latent bugs went with the duplication.** The baseline was drawn once (`.data([0]).enter()`) and never updated, so it went stale after a resize; it is now updated on every render. And the zero highlight was only ever added, never removed, so it stuck once data had crossed zero; it is recomputed each render.

**Also:** `_grid.scss` gains the vertical highlight rule, and `docs/API/grid.md` is regenerated (`docs:api`). One `patch` changeset on core.

## Motivation and Context

C4 in the v3 handoff audit, split on 11 Sep: the grid half is this PR; the tooltip half is bigger than a Could and is now M17. Audit rev 26/27 record both.

## How Has This Been Tested?

Node 24, macOS, no environment flags.

- `helpers/grid.spec.js`: **10/10** — line count per tick, edge hiding, extended line drawn / updated / removed, highlight added and cleared, vertical naming, band-scale centring, 2D pass-throughs.
- Core suite: **24 suites, 753 passing, 13 skipped** (up ten for the new spec). The line and stacked-area suites, which assert on `horizontal-grid-line--highlighted`, pass unchanged.
- `yarn build:packages` and `yarn test:integration`: tarball 21/21, require 5/5, types 2/2, browser 9/9 (the bar page renders through the new code).
- Lint: 0 errors, the 4 pre-existing warnings; Prettier clean.

No visual change is intended. The one DOM difference: the extended line moved from the grid group's parent (`.grid-lines-group`) into the grid group itself (`g.grid.horizontal` / `g.grid.vertical`). Nothing selects it by position and the CSS matches by class; the Chromatic run on this PR is the check.

## Screenshots (if appropriate):

N/A

## Types of changes

-   [x] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] Latest master code has been merged into this branch
-   [x] No commented out code (if required, place // TODO above with explanation)
-   [x] No linting issues
-   [x] Build is successful
-   [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [x] Updated the documentation
-   [x] Added tests to cover changes
-   [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wnD3atYJGPoq5JsmEDNbm
