### PR TITLE
feat(core): tooltip anchors and keys, phase 3

### DIFF
--- a/.changeset/react-tooltip-key-types.md
+++ b/.changeset/react-tooltip-key-types.md
@@ -1,0 +1,5 @@
+---
+'@britecharts/react': patch
+---
+
+The `Tooltip` component's `xAxisValueType` prop accepts `'auto'` (the default) and `'category'` besides `'date'` and `'number'`, and a `maxEntries` prop caps the rows shown; both in the typings too.

--- a/.changeset/tooltip-anchors-and-keys.md
+++ b/.changeset/tooltip-anchors-and-keys.md
@@ -1,0 +1,5 @@
+---
+'@britecharts/core': patch
+---
+
+The scatter plot's tooltip is anchored to the hovered point, in the chart's own coordinate space, so it sits beside the point and never covers it (#923); it used to be placed from root-svg coordinates and landed a margin's worth off. The tooltip's `xAxisValueType` gains `'category'`, which shows the key as it is, and `'auto'`, now the default, which shows a date as a date, a number as a number and anything else as it is, so a category key no longer titles the tooltip "NaN" (#825); `'date'` and `'number'` still force a type. When the data point has no field named by `dateLabel`, the title falls back to its `key` (what the stacked and grouped bar charts dispatch) or its `date`. A new `maxEntries` accessor (default 12) folds the rows past it into a "+n more" row, so a tooltip with many topics keeps a height that fits in the chart (#788). The stacked bar and grouped bar charts dispatch `customClick` only when a bar is clicked, and pass the clicked bar's own data as a third argument, after the column and the pointer position (#864).

--- a/packages/core/src/charts/grouped-bar/grouped-bar.js
+++ b/packages/core/src/charts/grouped-bar/grouped-bar.js
@@ -759,12 +759,24 @@ export default function module() {
      * @private
      */
     function handleCustomClick(e, d, event) {
+        // Like the hover, clicks are for the bars only
+        if (!isPointerOverBar(event)) {
+            return;
+        }
+
         let [mouseX, mouseY] = getMousePosition(event);
         let dataPoint = isHorizontal
             ? getNearestDataPoint2(mouseY)
             : getNearestDataPoint(mouseX);
 
-        dispatcher.call('customClick', e, dataPoint, pointer(event, e));
+        // The rect carries the clicked bar's own entry (group, name, value)
+        dispatcher.call(
+            'customClick',
+            e,
+            dataPoint,
+            pointer(event, e),
+            select(event.target).datum()
+        );
     }
 
     /**

--- a/packages/core/src/charts/grouped-bar/grouped-bar.spec.js
+++ b/packages/core/src/charts/grouped-bar/grouped-bar.spec.js
@@ -273,22 +273,31 @@ describe('grouped Bar Chart', () => {
 
     describe('lifecycle', () => {
         describe('when clicking on the chart', () => {
-            it('should trigger a callback', () => {
-                const bar = containerFixture.select('.grouped-bar');
+            it('should trigger a callback with the column, the pointer and the clicked bar', () => {
                 const callbackSpy = jest.fn();
-                const expectedCalls = 1;
-                const expectedArguments = 2;
-                let actualCalls;
-                let actualArgumentsNumber;
+                const expectedCallCount = 1;
+                const expectedArgumentsCount = 3;
 
                 groupedBarChart.on('customClick', callbackSpy);
-                bar.dispatch('click');
+                containerFixture
+                    .select('rect.bar')
+                    .dispatch('click', { bubbles: true });
 
-                actualCalls = callbackSpy.mock.calls.length;
-                actualArgumentsNumber = callbackSpy.mock.calls[0].length;
+                expect(callbackSpy.mock.calls).toHaveLength(expectedCallCount);
+                expect(callbackSpy.mock.calls[0]).toHaveLength(
+                    expectedArgumentsCount
+                );
+                expect(callbackSpy.mock.calls[0][2]).toBeDefined();
+            });
 
-                expect(actualCalls).toEqual(expectedCalls);
-                expect(actualArgumentsNumber).toEqual(expectedArguments);
+            it('should not trigger a callback when the empty space of the chart is clicked', () => {
+                const callbackSpy = jest.fn();
+                const expectedCallCount = 0;
+
+                groupedBarChart.on('customClick', callbackSpy);
+                containerFixture.select('.grouped-bar').dispatch('click');
+
+                expect(callbackSpy.mock.calls).toHaveLength(expectedCallCount);
             });
         });
 

--- a/packages/core/src/charts/scatter-plot/scatter-plot.js
+++ b/packages/core/src/charts/scatter-plot/scatter-plot.js
@@ -807,10 +807,26 @@ export default function module() {
 
         highlightDataPoint(pointData);
 
-        dispatcher.call('customMouseMove', e, pointData, pointer(event, e), [
-            chartWidth,
-            chartHeight,
-        ]);
+        dispatcher.call(
+            'customMouseMove',
+            e,
+            pointData,
+            getPointPosition(pointData),
+            [chartWidth, chartHeight]
+        );
+    }
+
+    /**
+     * Where a point is drawn, in the coordinate space of the chart's
+     * drawing area -- the space the tooltip lives in. The tooltip is
+     * anchored to the point itself rather than to the pointer, so it sits
+     * beside the point and stays put while the pointer moves within it.
+     * @param  {Object} pointData   The point, with x and y in data units
+     * @return {Number[]}           [x, y] in pixels
+     * @private
+     */
+    function getPointPosition(pointData) {
+        return [xScale(pointData.x), yScale(pointData.y)];
     }
 
     /**
@@ -819,7 +835,14 @@ export default function module() {
      * @private
      */
     function handleMouseOver(e, d, event) {
-        dispatcher.call('customMouseOver', e, d, pointer(event, e));
+        const pointData = getPointData(getClosestPoint(e, event));
+
+        dispatcher.call(
+            'customMouseOver',
+            e,
+            pointData,
+            getPointPosition(pointData)
+        );
     }
 
     /**

--- a/packages/core/src/charts/stacked-bar/stacked-bar.js
+++ b/packages/core/src/charts/stacked-bar/stacked-bar.js
@@ -13,6 +13,7 @@ import 'd3-transition';
 import { exportChart } from '../helpers/export';
 import { getValueDomain } from '../helpers/domain';
 import { dataKeyDeprecationMessage } from '../helpers/project';
+import { isDefined } from '../helpers/type';
 import colorHelper from '../helpers/color';
 import { barLoadingMarkup } from '../helpers/load';
 import { setDefaultLocale } from '../helpers/locale';
@@ -745,12 +746,62 @@ export default function module() {
      * @private
      */
     function handleClick(e, d, event) {
+        // Like the hover, clicks are for the bars only
+        if (!isPointerOverBar(event)) {
+            return;
+        }
+
         let [mouseX, mouseY] = getMousePosition(event);
         let dataPoint = isHorizontal
             ? getNearestDataPoint2(mouseY)
             : getNearestDataPoint(mouseX);
 
-        dispatcher.call('customClick', e, dataPoint, pointer(event, e));
+        dispatcher.call(
+            'customClick',
+            e,
+            dataPoint,
+            pointer(event, e),
+            getSegment(event.target)
+        );
+    }
+
+    /**
+     * The data of one bar (one segment of a stack): its stack's name, its
+     * value and the key of the column it belongs to. The rect's layer
+     * carries the stack's name; the column is the rect's position within
+     * the layer, which follows the order of the data (the stacked point
+     * itself carries the column as `data` when d3 bound it)
+     * @param  {Element} bar    The clicked rect
+     * @return {Object | undefined}
+     * @private
+     */
+    function getSegment(bar) {
+        const layerNode = bar.parentNode;
+        const layer = layerNode ? select(layerNode).datum() : null;
+
+        if (!layer || !isDefined(layer.key)) {
+            return undefined;
+        }
+
+        const point = select(bar).datum();
+        const column =
+            point && point.data
+                ? point.data
+                : transformedData[
+                      Array.from(layerNode.querySelectorAll('.bar')).indexOf(
+                          bar
+                      )
+                  ];
+
+        if (!column) {
+            return undefined;
+        }
+
+        return {
+            name: layer.key,
+            value: column[layer.key],
+            key: column.key,
+        };
     }
 
     /**

--- a/packages/core/src/charts/stacked-bar/stacked-bar.spec.js
+++ b/packages/core/src/charts/stacked-bar/stacked-bar.spec.js
@@ -276,21 +276,31 @@ describe('stacked Bar Chart', () => {
 
     describe('lifecycle', () => {
         describe('when clicking on the chart', () => {
-            it('should trigger a callback', () => {
-                const chart = containerFixture.select('.stacked-bar');
+            it('should trigger a callback with the column, the pointer and the clicked bar', () => {
                 const callbackSpy = jest.fn();
                 const expectedCallCount = 1;
-                const expectedArgumentsCount = 2;
-                let actualCalls;
-                let actualArgumentsNumber;
+                const expectedArgumentsCount = 3;
 
                 stackedBarChart.on('customClick', callbackSpy);
-                chart.dispatch('click');
-                actualCalls = callbackSpy.mock.calls.length;
-                actualArgumentsNumber = callbackSpy.mock.calls[0].length;
+                containerFixture
+                    .select('rect.bar')
+                    .dispatch('click', { bubbles: true });
 
-                expect(actualCalls).toEqual(expectedCallCount);
-                expect(actualArgumentsNumber).toEqual(expectedArgumentsCount);
+                expect(callbackSpy.mock.calls).toHaveLength(expectedCallCount);
+                expect(callbackSpy.mock.calls[0]).toHaveLength(
+                    expectedArgumentsCount
+                );
+                expect(callbackSpy.mock.calls[0][2]).toBeDefined();
+            });
+
+            it('should not trigger a callback when the empty space of the chart is clicked', () => {
+                const callbackSpy = jest.fn();
+                const expectedCallCount = 0;
+
+                stackedBarChart.on('customClick', callbackSpy);
+                containerFixture.select('.stacked-bar').dispatch('click');
+
+                expect(callbackSpy.mock.calls).toHaveLength(expectedCallCount);
             });
         });
 

--- a/packages/core/src/charts/tooltip/tooltip.js
+++ b/packages/core/src/charts/tooltip/tooltip.js
@@ -11,9 +11,13 @@ import {
     isInteger,
 } from '../helpers/number';
 import { getTextWidth, getApproximateNumberOfLines } from '../helpers/text';
+import { isDefined } from '../helpers/type';
 import { measureFrame, originOf, translateOf } from './frame';
 import { chaseDuration, ease, prepareToShow, fadeIn, fadeOut } from './motion';
 import { place } from './place';
+
+// Key of the row that stands for the topics past maxEntries
+const MORE_ROW_KEY = '__more__';
 
 /**
  * Tooltip Component reusable API class that renders a
@@ -110,7 +114,9 @@ export default function module() {
         nameLabel = 'name',
         topicLabel = 'topics',
         defaultAxisSettings = axisTimeCombinations.DAY_MONTH,
-        xAxisValueType = 'date',
+        xAxisValueType = 'auto',
+        // Rows shown before the rest are folded into a "+n more" row
+        maxEntries = 12,
         dateFormat = null,
         dateCustomFormat = null,
         topicsOrder = [],
@@ -364,8 +370,11 @@ export default function module() {
      */
     function layoutEntry(entry, topic) {
         const name = topic[nameLabel];
-        const leftText = topic.topicName || name;
-        const rightText = getValueText(topic);
+        const isMoreRow = !!topic.isMoreRow;
+        const leftText = isMoreRow
+            ? `+${topic.hiddenCount} more`
+            : topic.topicName || name;
+        const rightText = isMoreRow ? '' : getValueText(topic);
         const left = entry.select('.tooltip-left-text');
         const right = entry.select('.tooltip-right-text');
 
@@ -408,7 +417,10 @@ export default function module() {
         textHeight = measuredTextHeight || textHeight;
         tooltipHeight += textHeight + tooltipTextLinePadding;
 
-        entry.select('.tooltip-circle').style('fill', colorMap[name]);
+        entry
+            .select('.tooltip-circle')
+            .style('display', isMoreRow ? 'none' : null)
+            .style('fill', isMoreRow ? null : colorMap[name]);
 
         ttTextY += textHeight + 7;
     }
@@ -471,11 +483,72 @@ export default function module() {
      * @private
      */
     function formatKey(key) {
-        if (xAxisValueType === 'number') {
+        if (!isDefined(key)) {
+            return '';
+        }
+
+        const type =
+            xAxisValueType === 'auto' ? detectKeyType(key) : xAxisValueType;
+
+        if (type === 'number') {
             return Number(key);
         }
 
+        if (type === 'category') {
+            return String(key);
+        }
+
         return formatDate(new Date(key));
+    }
+
+    /**
+     * Works out how to show a key when xAxisValueType is 'auto': a Date or
+     * a string that parses as one is a date, a number or a numeric string
+     * is a number, anything else (a category name) is shown as it is
+     * @param  {Date | Number | String} key   Key of the data point
+     * @return {'date' | 'number' | 'category'}
+     * @private
+     */
+    function detectKeyType(key) {
+        if (key instanceof Date) {
+            return 'date';
+        }
+
+        if (typeof key === 'number') {
+            return 'number';
+        }
+
+        const text = String(key).trim();
+
+        if (text !== '' && Number.isFinite(Number(text))) {
+            return 'number';
+        }
+
+        if (Number.isFinite(Date.parse(text))) {
+            return 'date';
+        }
+
+        return 'category';
+    }
+
+    /**
+     * The key of a data point: the configured dateLabel, or, when the point
+     * has no such field, its `key` (what the stacked and grouped bar charts
+     * dispatch) or its `date`
+     * @param  {Object} dataPoint   The hovered data point
+     * @return {Date | Number | String | undefined}
+     * @private
+     */
+    function getKey(dataPoint) {
+        if (isDefined(dataPoint[dateLabel])) {
+            return dataPoint[dateLabel];
+        }
+
+        if (isDefined(dataPoint.key)) {
+            return dataPoint.key;
+        }
+
+        return dataPoint.date;
     }
 
     /**
@@ -586,7 +659,7 @@ export default function module() {
      * @private
      */
     function updateTitle(dataPoint) {
-        const textTitle = getTooltipTitle(dataPoint[dateLabel]);
+        const textTitle = getTooltipTitle(getKey(dataPoint));
 
         tooltipTitle
             .text(textTitle)
@@ -603,7 +676,7 @@ export default function module() {
         let formattedDate = formatKey(date);
 
         if (textTitle.length) {
-            if (shouldShowDateInTitle) {
+            if (shouldShowDateInTitle && formattedDate !== '') {
                 textTitle = `${textTitle} - ${formattedDate}`;
             }
         } else {
@@ -718,6 +791,22 @@ export default function module() {
             topics = _sortByAlpha(topics);
         }
 
+        topics = topics.filter(Boolean);
+
+        // Past maxEntries the last row says how many are not shown, so the
+        // box keeps a height that fits in the chart
+        if (maxEntries > 0 && topics.length > maxEntries) {
+            const shown = topics.slice(0, maxEntries - 1);
+
+            topics = shown.concat([
+                {
+                    [nameLabel]: MORE_ROW_KEY,
+                    isMoreRow: true,
+                    hiddenCount: topics.length - shown.length,
+                },
+            ]);
+        }
+
         updateTitle(dataPoint);
         resetSizeAndPositionPointers();
 
@@ -726,7 +815,7 @@ export default function module() {
         // every node
         const entries = tooltipBody
             .selectAll('.tooltip-entry')
-            .data(topics.filter(Boolean), (topic) => topic[nameLabel]);
+            .data(topics, (topic) => topic[nameLabel]);
 
         entries.exit().remove();
 
@@ -800,7 +889,10 @@ export default function module() {
     };
 
     /**
-     * Gets or Sets the dateLabel of the data
+     * Gets or Sets the dateLabel of the data: the field of the data point
+     * shown in the title. When the data point has no such field, its `key`
+     * (what the stacked and grouped bar charts dispatch) or its `date` is
+     * used, so the default works for every chart.
      * @param  {String} _x          Desired dateLabel
      * @return {String | module}   Current dateLabel or Chart module to chain calls
      * @public
@@ -951,6 +1043,24 @@ export default function module() {
     };
 
     /**
+     * Gets or Sets the most rows the tooltip shows. Past that, the last row
+     * reads "+n more" instead, so the box keeps a height that fits in the
+     * chart. 0 shows every row.
+     * @param  {Number} [_x=12]      Most rows to show
+     * @return {Number | module}    Current maxEntries or Chart module to chain calls
+     * @public
+     * @example tooltip.maxEntries(6)
+     */
+    exports.maxEntries = function (_x) {
+        if (!arguments.length) {
+            return maxEntries;
+        }
+        maxEntries = _x;
+
+        return this;
+    };
+
+    /**
      * Pass an override for the ordering of your tooltip
      * @param  {String[]} _x           Array of the names of your tooltip items
      * @return {String[] | module}    Current overrideOrder or Chart module to chain calls
@@ -1023,11 +1133,17 @@ export default function module() {
     };
 
     /**
-     * Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'. When set to
-     * number, the x-Axis values won't be parsed as dates anymore, but as numbers.
-     * @param  {String} [_x='date']     Desired keyType
-     * @return {String | module}        Current keyType or Chart module to chain calls
+     * Gets or Sets how the key of the data point is shown in the title:
+     * 'date' formats it as a date, 'number' as a number, 'category' shows
+     * it as it is, and 'auto' (the default) picks one per key -- a Date or
+     * a string that parses as one is a date, a number or a numeric string
+     * is a number, anything else is a category. Set 'date' for keys that
+     * happen to parse as numbers, or 'category' for names that happen to
+     * parse as dates.
+     * @param  {String} [_x='auto']     'auto', 'date', 'number' or 'category'
+     * @return {String | module}        Current xAxisValueType or Chart module to chain calls
      * @public
+     * @example tooltip.xAxisValueType('category')
      */
     exports.xAxisValueType = function (_x) {
         if (!arguments.length) {

--- a/packages/core/src/charts/tooltip/tooltip.spec.js
+++ b/packages/core/src/charts/tooltip/tooltip.spec.js
@@ -288,6 +288,123 @@ describe('tooltip Component', () => {
         });
     });
 
+    describe('title key', () => {
+        const titleOf = () => containerFixture.select('.tooltip-title').text();
+
+        beforeEach(() => {
+            // No title, so the text is the formatted key alone
+            tooltipChart.title('');
+        });
+        const pointWith = (key) => ({
+            date: key,
+            topics: [{ name: 'a', topicName: 'a', value: 1 }],
+        });
+
+        it('should show a date key as a date by default', () => {
+            tooltipChart.update(
+                pointWith('2015-08-05T07:00:00.000Z'),
+                topicColorMap,
+                0
+            );
+
+            expect(titleOf()).toEqual('Aug 05, 2015');
+        });
+
+        it('should show a category key as it is by default', () => {
+            tooltipChart.update(pointWith('Chicago'), topicColorMap, 0);
+
+            expect(titleOf()).toEqual('Chicago');
+        });
+
+        it('should show a numeric key as a number by default', () => {
+            tooltipChart.update(pointWith('42'), topicColorMap, 0);
+
+            expect(titleOf()).toEqual('42');
+        });
+
+        it('should show a category key as it is when told so, even if it parses as a date', () => {
+            tooltipChart.xAxisValueType('category');
+            tooltipChart.update(pointWith('2015'), topicColorMap, 0);
+
+            expect(titleOf()).toEqual('2015');
+        });
+
+        it('should fall back to the key field of the data point', () => {
+            tooltipChart.update(
+                {
+                    key: 'Chicago',
+                    topics: [{ name: 'a', topicName: 'a', value: 1 }],
+                },
+                topicColorMap,
+                0
+            );
+
+            expect(titleOf()).toEqual('Chicago');
+        });
+
+        it('should show only the title when the data point has no key', () => {
+            tooltipChart.title('Sales');
+            tooltipChart.update(
+                { topics: [{ name: 'a', topicName: 'a', value: 1 }] },
+                topicColorMap,
+                0
+            );
+
+            expect(titleOf()).toEqual('Sales');
+        });
+    });
+
+    describe('many rows', () => {
+        const pointWithRows = (count) => ({
+            date: '2015-08-05T07:00:00.000Z',
+            topics: Array.from({ length: count }, (_, index) => ({
+                name: `topic-${String(index).padStart(2, '0')}`,
+                topicName: `Topic ${index}`,
+                value: index,
+            })),
+        });
+        const rowTexts = () =>
+            containerFixture
+                .selectAll('.tooltip-left-text')
+                .nodes()
+                .map((node) => node.textContent);
+
+        it('should show every row up to maxEntries', () => {
+            tooltipChart.update(pointWithRows(12), topicColorMap, 0);
+
+            expect(rowTexts()).toHaveLength(12);
+        });
+
+        it('should fold the rows past maxEntries into a "+n more" row', () => {
+            tooltipChart.update(pointWithRows(20), topicColorMap, 0);
+
+            const texts = rowTexts();
+
+            expect(texts).toHaveLength(12);
+            expect(texts[11]).toEqual('+9 more');
+            expect(
+                containerFixture
+                    .selectAll('.tooltip-entry')
+                    .filter(function () {
+                        return (
+                            d3
+                                .select(this)
+                                .select('.tooltip-circle')
+                                .style('display') === 'none'
+                        );
+                    })
+                    .size()
+            ).toEqual(1);
+        });
+
+        it('should show every row when maxEntries is 0', () => {
+            tooltipChart.maxEntries(0);
+            tooltipChart.update(pointWithRows(20), topicColorMap, 0);
+
+            expect(rowTexts()).toHaveLength(20);
+        });
+    });
+
     describe('lifecycle', () => {
         const settle = () => new Promise((resolve) => setTimeout(resolve, 300));
         const aDataPoint = (names) => ({
@@ -761,10 +878,21 @@ describe('tooltip Component', () => {
             expect(actual).toBe(expected);
         });
 
-        it('default of xAxisValueType should be "date"', () => {
-            let current = tooltipChart.xAxisValueType();
+        it('default of xAxisValueType should be "auto"', () => {
+            const expected = 'auto';
+            const actual = tooltipChart.xAxisValueType();
 
-            expect(current).toBe('date');
+            expect(actual).toEqual(expected);
+        });
+
+        it('should provide maxEntries getter and setter', () => {
+            const defaultMaxEntries = tooltipChart.maxEntries();
+            const expected = 6;
+
+            tooltipChart.maxEntries(expected);
+
+            expect(defaultMaxEntries).toEqual(12);
+            expect(tooltipChart.maxEntries()).toEqual(expected);
         });
     });
 });

--- a/packages/core/src/typings/charts/tooltip.d.ts
+++ b/packages/core/src/typings/charts/tooltip.d.ts
@@ -88,10 +88,17 @@ export interface TooltipAPI {
     /** Gets or Sets the valueLabel of the data */
     valueLabel(label?: string): TooltipModule;
     /**
-     * Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'. When set to
-     * number, the x-Axis values won't be parsed as dates anymore, but as numbers.
+     * Gets or Sets the most rows the tooltip shows; past that, the last row reads "+n more".
+     * 0 shows every row. Default 12.
+     */
+    maxEntries(limit?: number): TooltipModule;
+    /**
+     * Gets or Sets how the key of the data point is shown in the title: 'date', 'number',
+     * 'category' (as it is), or 'auto' (the default), which picks one per key.
      * */
-    xAxisValueType(type?: 'date' | 'number'): TooltipModule;
+    xAxisValueType(
+        type?: 'auto' | 'date' | 'number' | 'category'
+    ): TooltipModule;
 }
 
 export type TooltipModule = ChartModuleSelection<TooltipDataShape[]> &

--- a/packages/docs/docs/API/tooltip.md
+++ b/packages/docs/docs/API/tooltip.md
@@ -50,6 +50,7 @@ d3Selection.select('.metadata-group .hover-marker')
         * [.show()](#module_Tooltip--exports.show) ⇒ <code>module</code>
         * [.title(_x)](#module_Tooltip--exports.title) ⇒ <code>String</code> \| <code>module</code>
         * [.tooltipOffset(_x)](#module_Tooltip--exports.tooltipOffset) ⇒ <code>Object</code> \| <code>module</code>
+        * [.maxEntries([_x])](#module_Tooltip--exports.maxEntries) ⇒ <code>Number</code> \| <code>module</code>
         * [.topicsOrder(_x)](#module_Tooltip--exports.topicsOrder) ⇒ <code>Array.&lt;String&gt;</code> \| <code>module</code>
         * ~~[.topicLabel(_x)](#module_Tooltip--exports.topicLabel) ⇒ <code>String</code> \| <code>module</code>~~
         * [.update(dataPoint, colorMapping, xPosition, [yPosition])](#module_Tooltip--exports.update) ⇒ <code>Module</code>
@@ -115,7 +116,10 @@ tooltip.dateCustomFormat('%H:%M %p')
 ### ~~exports.dateLabel(_x) ⇒ <code>String</code> \| <code>module</code>~~
 ***Deprecated***
 
-Gets or Sets the dateLabel of the data
+Gets or Sets the dateLabel of the data: the field of the data point
+shown in the title. When the data point has no such field, its `key`
+(what the stacked and grouped bar charts dispatch) or its `date` is
+used, so the default works for every chart.
 
 **Kind**: static method of [<code>exports</code>](#exp_module_Tooltip--exports)  
 **Returns**: <code>String</code> \| <code>module</code> - Current dateLabel or Chart module to chain calls  
@@ -245,6 +249,25 @@ up (negative) or down. The box still stays inside the chart.
 ```js
 tooltip.tooltipOffset({ x: 0, y: -20 })
 ```
+<a name="module_Tooltip--exports.maxEntries"></a>
+
+### exports.maxEntries([_x]) ⇒ <code>Number</code> \| <code>module</code>
+Gets or Sets the most rows the tooltip shows. Past that, the last row
+reads "+n more" instead, so the box keeps a height that fits in the
+chart. 0 shows every row.
+
+**Kind**: static method of [<code>exports</code>](#exp_module_Tooltip--exports)  
+**Returns**: <code>Number</code> \| <code>module</code> - Current maxEntries or Chart module to chain calls  
+**Access**: public  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [_x] | <code>Number</code> | <code>12</code> | Most rows to show |
+
+**Example**  
+```js
+tooltip.maxEntries(6)
+```
 <a name="module_Tooltip--exports.topicsOrder"></a>
 
 ### exports.topicsOrder(_x) ⇒ <code>Array.&lt;String&gt;</code> \| <code>module</code>
@@ -309,14 +332,23 @@ Gets or Sets the valueLabel of the data
 <a name="module_Tooltip--exports.xAxisValueType"></a>
 
 ### exports.xAxisValueType([_x]) ⇒ <code>String</code> \| <code>module</code>
-Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'. When set to
-number, the x-Axis values won't be parsed as dates anymore, but as numbers.
+Gets or Sets how the key of the data point is shown in the title:
+'date' formats it as a date, 'number' as a number, 'category' shows
+it as it is, and 'auto' (the default) picks one per key -- a Date or
+a string that parses as one is a date, a number or a numeric string
+is a number, anything else is a category. Set 'date' for keys that
+happen to parse as numbers, or 'category' for names that happen to
+parse as dates.
 
 **Kind**: static method of [<code>exports</code>](#exp_module_Tooltip--exports)  
-**Returns**: <code>String</code> \| <code>module</code> - Current keyType or Chart module to chain calls  
+**Returns**: <code>String</code> \| <code>module</code> - Current xAxisValueType or Chart module to chain calls  
 **Access**: public  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| [_x] | <code>String</code> | <code>&#x27;date&#x27;</code> | Desired keyType |
+| [_x] | <code>String</code> | <code>&#x27;auto&#x27;</code> | 'auto', 'date', 'number' or 'category' |
 
+**Example**  
+```js
+tooltip.xAxisValueType('category')
+```

--- a/packages/integration/tests/hover.spec.js
+++ b/packages/integration/tests/hover.spec.js
@@ -15,7 +15,8 @@ const INSET = 4;
 // Both tooltips move over a short transition; let it settle before measuring.
 const SETTLE_MS = 300;
 
-// [name, container, where the pointer goes, tooltip root]. The pointer has
+// [name, container, where the pointer goes, tooltip root, and optionally
+// the anchor the tooltip must not cover]. The pointer has
 // to land where the chart resolves a data point, which differs per chart:
 //   svg          — anywhere over the svg: five points, corners and centre
 //                  (line snaps to the nearest date; scatter to the nearest point)
@@ -59,6 +60,9 @@ const CHARTS = [
         '.hover-scatter-plot',
         'svg',
         '.britechart-mini-tooltip',
+        // The tooltip is anchored to the hovered point and must never
+        // cover it (#923)
+        'circle.highlight-circle',
     ],
     [
         'heatmap + mini tooltip',
@@ -151,7 +155,13 @@ function nanAttributes(container) {
     );
 }
 
-for (const [name, selector, target, tooltipSelector] of CHARTS) {
+for (const [
+    name,
+    selector,
+    target,
+    tooltipSelector,
+    anchorSelector,
+] of CHARTS) {
     test(`H · ${name} stays inside the chart`, async ({ page }) => {
         const problems = [];
 
@@ -236,6 +246,43 @@ for (const [name, selector, target, tooltipSelector] of CHARTS) {
                 `${where}: bottom edge`
             ).toBeLessThanOrEqual(frame.y + frame.height + 1);
             expect(await nanAttributes(container), where).toEqual([]);
+
+            if (anchorSelector) {
+                // The anchor's geometry, not its bounding box: a glow filter
+                // makes the box much bigger than the point itself.
+                const anchor = await container
+                    .locator(anchorSelector)
+                    .evaluate((el) => {
+                        const matrix = el.getScreenCTM();
+                        const centre = new DOMPoint(
+                            Number(el.getAttribute('cx')),
+                            Number(el.getAttribute('cy'))
+                        ).matrixTransform(matrix);
+
+                        return {
+                            x: centre.x,
+                            y: centre.y,
+                            r: Number(el.getAttribute('r')) * matrix.a,
+                        };
+                    });
+                const nearestX = Math.max(
+                    box.x,
+                    Math.min(anchor.x, box.x + box.width)
+                );
+                const nearestY = Math.max(
+                    box.y,
+                    Math.min(anchor.y, box.y + box.height)
+                );
+                const distance = Math.hypot(
+                    anchor.x - nearestX,
+                    anchor.y - nearestY
+                );
+
+                expect(
+                    distance,
+                    `${where}: covers the hovered point`
+                ).toBeGreaterThanOrEqual(anchor.r);
+            }
         }
 
         // Leaving the chart hides it again.

--- a/packages/react/src/charts/tooltip/Tooltip.js
+++ b/packages/react/src/charts/tooltip/Tooltip.js
@@ -102,10 +102,16 @@ export default class Tooltip extends React.Component {
         valueLabel: PropTypes.string,
 
         /**
-         * Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'.
-         * When set to number, the x-Axis values won't be parsed as dates anymore, but as numbers.
+         * Gets or Sets the most rows the tooltip shows; past that, the last row reads "+n more".
+         * 0 shows every row. Default 12.
          */
-        xAxisValueType: PropTypes.string,
+        maxEntries: PropTypes.number,
+
+        /**
+         * Gets or Sets how the key of the data point is shown in the title: 'date', 'number',
+         * 'category' (as it is), or 'auto' (the default), which picks one per key.
+         */
+        xAxisValueType: PropTypes.oneOf(['auto', 'date', 'number', 'category']),
 
         /**
          * Internally used, do not overwrite.

--- a/packages/react/src/typings/charts/Tooltip.d.ts
+++ b/packages/react/src/typings/charts/Tooltip.d.ts
@@ -91,10 +91,16 @@ export interface TooltipProps {
     valueLabel?: string;
 
     /**
-     * Gets or Sets the `xAxisValueType` of the data. Choose between 'date' and 'number'.
-     * When set to number, the x-Axis values won't be parsed as dates anymore, but as numbers.
+     * Gets or Sets the most rows the tooltip shows; past that, the last row reads "+n more".
+     * 0 shows every row. Default 12.
      */
-    xAxisValueType: 'date' | 'number';
+    maxEntries?: number;
+
+    /**
+     * Gets or Sets how the key of the data point is shown in the title: 'date', 'number',
+     * 'category' (as it is), or 'auto' (the default), which picks one per key.
+     */
+    xAxisValueType?: 'auto' | 'date' | 'number' | 'category';
 
     /**
      * Internally used, do not overwrite.


### PR DESCRIPTION
## Description

Phase 3 of the tooltip rework (M17, plan in `managing-docs/tooltip-rework-plan.md`): the anchors and the adjacent tooltip issues.

**Scatter plot: the tooltip sits beside the point (#923).** The chart dispatched the pointer in root-svg coordinates into a tooltip that lives in the margin-translated group, so the box landed a margin's worth off and overlapped the point. It now dispatches the hovered point's own position in the chart's coordinate space, on mouseover as well as on mousemove, so the tooltip is anchored to the point and stays put while the pointer moves within it. The hover test asserts the box never covers the highlighted point.

**Category and automatic keys in the title (#825).** `xAxisValueType` gains `'category'`, which shows the key as it is, and `'auto'`, now the default: a date shows as a date, a number as a number, anything else as it is. A category key no longer titles the tooltip "NaN". `'date'` and `'number'` still force a type. When the data point has no field named by `dateLabel`, the title falls back to its `key` (what the stacked and grouped bar charts dispatch) or its `date`, so the default works on every chart.

**Many rows (#788).** A new `maxEntries` accessor, default 12 and 0 for all, folds the rows past it into a "+n more" row, so a tooltip with many topics keeps a height that fits in the chart.

**Clicking a bar (#864).** The stacked bar and grouped bar charts dispatch `customClick` only when a bar is clicked, in line with their hover, and pass the clicked bar's own data as a third argument after the column and the pointer position: for the grouped bar its entry, for the stacked bar the stack's name, its value and the column's key.

Typings and the React `Tooltip` follow: `xAxisValueType` accepts the four values (and is no longer a required prop), `maxEntries` is new.

## Motivation and Context

Acceptance 2 ("follows the anchor") and 5 (category titles, many rows) of the plan; decisions D3, D5 and D6. Closes the tooltip issues #923, #825, #788 and #864 (#1042 closed in phase 1). Phase 4 (one component, unified `update`) is next.

## How Has This Been Tested?

- Hover suite in the integration package: 9 of 9, with a new assertion that the scatter tooltip never overlaps the highlighted point at any of the five pointer positions.
- Tooltip specs: default `'auto'`, the `maxEntries` accessor, six title-key cases (date, category, numeric, forced category, the `key` fallback, no key) and three many-rows cases. Stacked and grouped bar click specs rewritten for the three-argument payload and the empty space. Scatter suite unchanged.
- Full unit suite green; lint unchanged; API docs regenerated.
- The Integration check runs the types tier against the changed typings.

## Types of changes

-   [ ] Refactor (changes the way we code something without changing its functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

Note: `xAxisValueType` defaults to `'auto'` instead of `'date'`. Keys that parse as dates still show as dates; keys that did not used to show as "NaN" and now show as themselves or as numbers.

## Checklist:

-   [x] Latest master code has been merged into this branch
-   [x] No commented out code (if required, place // TODO above with explanation)
-   [x] No linting issues
-   [x] Build is successful
-   [x] Code follows the [API Guidelines](http://britecharts.github.io/britecharts/topics-index.html#toc5__anchor)
-   [x] Updated the documentation
-   [x] Added tests to cover changes
-   [x] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rU4eY7a3jwBnxFoB2vBn6
